### PR TITLE
[MG-5] Android: AndroidManifest에 wideColorGamut 활성화

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:colorMode="wideColorGamut"
         android:theme="@style/Theme.Mongle">
 
         <activity


### PR DESCRIPTION
## Jira
- [MG-5](https://ycompany.atlassian.net/browse/MG-5)

## Related
- iOS 대응 PR: rrheon/Mongle `fix/MG-5-color-display-p3`
- 후속 하위 PR: `fix/MG-7-android-color-p3` — Compose Color(0xFF...) 일괄 변환 (함께 머지 권장)

## Summary
- `AndroidManifest.xml` `<application>`에 `android:colorMode="wideColorGamut"` 추가
- Compose surface가 Display P3를 받을 준비. 완전한 파스텔톤 복원은 MG-7과 함께 적용

## Test plan
- [ ] 플래그십 Android 실기기 회귀 없음 확인
- [ ] MG-7 머지 후 중저가 단말에서 파스텔 복원 확인

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)