### PR TITLE
feat(i18n): 앱 이름 국가별 표시 — 한국 몽글 / 그 외 Monggle (MG-11)

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App -->
-    <string name="app_name">モングル</string>
+    <string name="app_name">Monggle</string>
 
     <!-- Common -->
     <string name="common_confirm">確認</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- App -->
-    <string name="app_name">Mongle</string>
+    <string name="app_name">Monggle</string>
 
     <!-- Common -->
     <string name="common_confirm">OK</string>


### PR DESCRIPTION
## Jira
- [MG-11](https://ycompany.atlassian.net/browse/MG-11)

## Related
- iOS 대응 PR: 작업 예정 (동일 MG-11)

## Summary
- `values/strings.xml` 기본 `app_name`을 `Mongle` → `Monggle`로 변경
- `values-ja/strings.xml` `app_name`을 `モングル` → `Monggle`로 변경
- `values-ko/strings.xml`의 `app_name = 몽글`은 유지

이로써 한국어 로케일에서만 "몽글"이 표시되고, 그 외 모든 로케일에서는 "Monggle"로 통일된다.

## Test plan
- [ ] 에뮬레이터 언어 한국어 → 홈 화면 "몽글"
- [ ] 에뮬레이터 언어 English → 홈 화면 "Monggle"
- [ ] 에뮬레이터 언어 日本語 → 홈 화면 "Monggle"
- [ ] 앱 내 스플래시·설정·상단바 타이틀 등 참조처 회귀 확인

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)