### PR TITLE
fix(notification): REMINDER 타입 추가 — 수신·리스트·라우팅 (MG-19)

### DIFF
--- a/app/src/main/java/com/mongle/android/domain/model/MongleNotification.kt
+++ b/app/src/main/java/com/mongle/android/domain/model/MongleNotification.kt
@@ -19,5 +19,6 @@ enum class NotificationType {
     ALL_ANSWERED,      // 모든 구성원이 답변 완료했을 때
     ANSWER_REQUEST,    // 누군가 나에게 답변 요청할 때
     TREE_GROWTH,
-    BADGE_EARNED
+    BADGE_EARNED,
+    REMINDER           // 서버 스케줄러가 발송하는 일반 리마인더 (답변 독려 등)
 }

--- a/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
+++ b/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
@@ -109,6 +109,12 @@ fun MongleNavHost(
                     uiState.todayQuestion?.let { showQuestionDetail = it }
                 }
             }
+            "REMINDER" -> {
+                // 서버 스케줄러 발송 일반 리마인더 — 홈(MainTab) 유지. 답변 전이면 질문 상세로 이동
+                if (!uiState.hasAnsweredToday) {
+                    uiState.todayQuestion?.let { showQuestionDetail = it }
+                }
+            }
         }
         rootViewModel.clearPendingNotification()
     }
@@ -292,6 +298,12 @@ fun MongleNavHost(
                                         }
                                         "member_answered" -> {
                                             uiState.todayQuestion?.let { showQuestionDetail = it }
+                                        }
+                                        "reminder" -> {
+                                            // 리마인더는 답변 전이면 질문 상세로, 이미 답변했으면 홈 유지
+                                            if (!uiState.hasAnsweredToday) {
+                                                uiState.todayQuestion?.let { showQuestionDetail = it }
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.CardGiftcard
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.QuestionMark
 import androidx.compose.material3.CircularProgressIndicator
@@ -451,6 +452,8 @@ private fun notificationTypeStyle(type: String): NotifStyle = when (type.lowerca
     "all_answered" -> NotifStyle(Color(0xFFE8F6EA), Icons.Default.CheckCircle, Color(0xFF4CAF50))
     "answer_request" -> NotifStyle(Color(0xFFFFF1E2), Icons.Default.Campaign, Color(0xFFFF9800))
     "badge_earned" -> NotifStyle(Color(0xFFFDDDD8), Icons.Default.CardGiftcard, Color(0xFFFF8A80))
+    // 서버 스케줄러가 발송하는 일반 리마인더 — 보라 계열 틴트로 구분
+    "reminder" -> NotifStyle(Color(0xFFEDE7F6), Icons.Default.Notifications, Color(0xFF7E57C2))
     else -> NotifStyle(Color(0xFFF5F5F5), Icons.Default.QuestionMark, Color(0xFF9E9E9E))
 }
 


### PR DESCRIPTION
## Summary
- 서버가 새로 발송하는 FCM push type `REMINDER` 를 앱이 인식·표시·라우팅하도록 iOS 와 동일 패턴 적용.
- `NotificationType` enum 에 `REMINDER` 추가, 알림 리스트 UI 에 보라 틴트 + Material Icons `Notifications` 벨 아이콘 추가, 라우팅 분기(`MongleNavHost`) 에 `REMINDER` 케이스 추가.
- 데이터 레이어(`ApiNotificationRepository`/`NotificationDto`) 는 `type` 을 문자열로 통과시키며 unknown drop 로직이 없어 별도 변경 불필요. 알 수 없는 타입은 기본 폴백 스타일로 표시됨.

## 변경 파일
- `app/src/main/java/com/mongle/android/domain/model/MongleNotification.kt` — enum 에 `REMINDER` 추가
- `app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt` — `notificationTypeStyle` 에 `"reminder"` 매핑 추가
- `app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt` — `pendingNotificationType` 라우팅 및 리스트 탭 라우팅에 `REMINDER` 분기 추가 (답변 전이면 QuestionDetail, 답변했으면 홈 유지)

## 동작
- 시스템 트레이: `MongleFcmService.showNotification` 은 title 이 있으면 type 과 무관하게 표시하므로 `REMINDER` 도 그대로 노출.
- 탭: `PendingIntent` 에 `notification_type=REMINDER` extra 가 실려 `MainActivity` 가 `RootViewModel.handleNotificationTap` 으로 전달 → `MongleNavHost` 의 새 분기에서 라우팅.
- 리스트: `NotificationScreen` 에서 `reminder` 는 보라 틴트 + 벨 아이콘으로 표시, 탭 시 답변 전이면 오늘의 질문 상세로 이동.

## 기존 회귀 방지
- `ANSWER_REQUEST`, `MEMBER_ANSWERED`, `NEW_QUESTION`, `ALL_ANSWERED`, `BADGE_EARNED` 분기는 변경하지 않음.
- Unknown 타입은 여전히 기본 폴백(`QuestionMark` + 회색) 으로 표시.

## Test plan
- [ ] FCM 테스트 콘솔에서 `data.type=REMINDER`, `notification.title/body` 를 포함한 푸시 전송 → 시스템 트레이 표시 확인
- [ ] 트레이 탭 시 앱 진입 후 오늘의 질문 미답변 상태면 QuestionDetail 로 진입하는지 확인
- [ ] 이미 답변한 상태면 홈(MainTab) 에 머무르는지 확인
- [ ] 알림 리스트(Notification Screen) 에 `REMINDER` 항목이 보라 틴트 + 벨 아이콘으로 렌더되는지 확인
- [ ] 리스트 항목 탭 시 답변 전이면 QuestionDetail, 답변 후면 홈 유지 확인
- [ ] `NEW_QUESTION`/`MEMBER_ANSWERED`/`ANSWER_REQUEST`/`BADGE_EARNED` 의 기존 아이콘·라우팅이 그대로 유지되는지 회귀 확인

## 빌드 검증
`./gradlew :app:compileDebugKotlin` 및 `:app:compileDebugUnitTestKotlin` 모두 성공 (로컬 google-services.json 패키지명 불일치는 기존 환경 이슈로 무관).

Closes #7
Refs: MG-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)