### PR TITLE
[MG-28] 계정 탈퇴·그룹 나가기 2차 확인 팝업 추가

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/settings/SettingsScreen.kt
@@ -231,7 +231,9 @@ fun SettingsScreen(
                     onKickMemberConfirmed = viewModel::onKickMemberConfirmed,
                     onKickMemberCancelled = viewModel::onKickMemberCancelled,
                     onLeaveGroupTapped = viewModel::onLeaveGroupTapped,
+                    onLeaveGroupFirstConfirmed = viewModel::onLeaveGroupFirstConfirmed,
                     onLeaveGroupConfirmed = viewModel::onLeaveGroupConfirmed,
+                    onLeaveGroupFinalCancelled = viewModel::onLeaveGroupFinalCancelled,
                     onLeaveGroupCancelled = viewModel::onLeaveGroupCancelled
                 )
             }
@@ -254,7 +256,9 @@ fun SettingsScreen(
                     onLogoutConfirmed = viewModel::onLogoutConfirmed,
                     onLogoutCancelled = viewModel::onLogoutCancelled,
                     onDeleteAccountTapped = viewModel::onDeleteAccountTapped,
+                    onDeleteAccountFirstConfirmed = viewModel::onDeleteAccountFirstConfirmed,
                     onDeleteAccountConfirmed = viewModel::onDeleteAccountConfirmed,
+                    onDeleteAccountFinalCancelled = viewModel::onDeleteAccountFinalCancelled,
                     onDeleteAccountCancelled = viewModel::onDeleteAccountCancelled
                 )
             }
@@ -738,7 +742,9 @@ private fun GroupManagementScreen(
     onKickMemberConfirmed: () -> Unit,
     onKickMemberCancelled: () -> Unit,
     onLeaveGroupTapped: () -> Unit,
+    onLeaveGroupFirstConfirmed: () -> Unit,
     onLeaveGroupConfirmed: () -> Unit,
+    onLeaveGroupFinalCancelled: () -> Unit,
     onLeaveGroupCancelled: () -> Unit
 ) {
     val context = LocalContext.current
@@ -761,7 +767,7 @@ private fun GroupManagementScreen(
         }
     }
 
-    // 그룹 나가기 확인
+    // 그룹 나가기 1차 확인
     if (uiState.showLeaveGroupConfirmation) {
         Dialog(
             onDismissRequest = onLeaveGroupCancelled,
@@ -771,9 +777,27 @@ private fun GroupManagementScreen(
                 title = stringResource(R.string.mgmt_leave_title),
                 description = stringResource(R.string.mgmt_leave_desc),
                 primaryLabel = stringResource(R.string.mgmt_leave_btn),
-                onPrimary = onLeaveGroupConfirmed,
+                onPrimary = onLeaveGroupFirstConfirmed,
                 secondaryLabel = stringResource(R.string.common_cancel),
                 onSecondary = onLeaveGroupCancelled,
+                isDestructive = true
+            )
+        }
+    }
+
+    // 그룹 나가기 2차 확인 (Context-aware final confirm)
+    if (uiState.showLeaveGroupFinalConfirmation) {
+        Dialog(
+            onDismissRequest = onLeaveGroupFinalCancelled,
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            MonglePopup(
+                title = stringResource(R.string.group_leave_final_title),
+                description = stringResource(R.string.group_leave_final_desc),
+                primaryLabel = stringResource(R.string.group_leave_final_confirm),
+                onPrimary = onLeaveGroupConfirmed,
+                secondaryLabel = stringResource(R.string.group_leave_final_cancel),
+                onSecondary = onLeaveGroupFinalCancelled,
                 isDestructive = true
             )
         }
@@ -1037,7 +1061,9 @@ private fun AccountManagementScreen(
     onLogoutConfirmed: () -> Unit,
     onLogoutCancelled: () -> Unit,
     onDeleteAccountTapped: () -> Unit,
+    onDeleteAccountFirstConfirmed: () -> Unit,
     onDeleteAccountConfirmed: () -> Unit,
+    onDeleteAccountFinalCancelled: () -> Unit,
     onDeleteAccountCancelled: () -> Unit
 ) {
     // 로그아웃 확인 다이얼로그
@@ -1058,7 +1084,7 @@ private fun AccountManagementScreen(
         }
     }
 
-    // 계정 탈퇴 확인 다이얼로그
+    // 계정 탈퇴 1차 확인 다이얼로그
     if (uiState.showDeleteAccountConfirmation) {
         Dialog(
             onDismissRequest = onDeleteAccountCancelled,
@@ -1068,9 +1094,27 @@ private fun AccountManagementScreen(
                 title = stringResource(R.string.settings_delete_account),
                 description = stringResource(R.string.settings_delete_confirm),
                 primaryLabel = stringResource(R.string.settings_delete_btn),
-                onPrimary = onDeleteAccountConfirmed,
+                onPrimary = onDeleteAccountFirstConfirmed,
                 secondaryLabel = stringResource(R.string.common_cancel),
                 onSecondary = onDeleteAccountCancelled,
+                isDestructive = true
+            )
+        }
+    }
+
+    // 계정 탈퇴 2차 확인 다이얼로그 (Context-aware final confirm)
+    if (uiState.showDeleteAccountFinalConfirmation) {
+        Dialog(
+            onDismissRequest = onDeleteAccountFinalCancelled,
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            MonglePopup(
+                title = stringResource(R.string.settings_delete_final_title),
+                description = stringResource(R.string.settings_delete_final_desc),
+                primaryLabel = stringResource(R.string.settings_delete_final_confirm),
+                onPrimary = onDeleteAccountConfirmed,
+                secondaryLabel = stringResource(R.string.settings_delete_final_cancel),
+                onSecondary = onDeleteAccountFinalCancelled,
                 isDestructive = true
             )
         }

--- a/app/src/main/java/com/mongle/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/settings/SettingsViewModel.kt
@@ -34,7 +34,9 @@ data class SettingsUiState(
     val isLoading: Boolean = false,
     val showLogoutConfirmation: Boolean = false,
     val showDeleteAccountConfirmation: Boolean = false,
+    val showDeleteAccountFinalConfirmation: Boolean = false,
     val showLeaveGroupConfirmation: Boolean = false,
+    val showLeaveGroupFinalConfirmation: Boolean = false,
     val showTransferSheet: Boolean = false,
     val selectedTransferMemberId: java.util.UUID? = null,
     val showKickConfirmation: Boolean = false,
@@ -208,9 +210,17 @@ class SettingsViewModel @Inject constructor(
         _uiState.update { it.copy(showLeaveGroupConfirmation = true) }
     }
 
+    fun onLeaveGroupFirstConfirmed() {
+        _uiState.update { it.copy(showLeaveGroupConfirmation = false, showLeaveGroupFinalConfirmation = true) }
+    }
+
+    fun onLeaveGroupFinalCancelled() {
+        _uiState.update { it.copy(showLeaveGroupFinalConfirmation = false) }
+    }
+
     fun onLeaveGroupConfirmed() {
         val state = _uiState.value
-        _uiState.update { it.copy(showLeaveGroupConfirmation = false) }
+        _uiState.update { it.copy(showLeaveGroupConfirmation = false, showLeaveGroupFinalConfirmation = false) }
 
         if (state.isOwner && state.transferCandidates.isNotEmpty()) {
             // 방장이고 다른 멤버가 있으면 위임 시트 표시
@@ -234,7 +244,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun onLeaveGroupCancelled() {
-        _uiState.update { it.copy(showLeaveGroupConfirmation = false) }
+        _uiState.update { it.copy(showLeaveGroupConfirmation = false, showLeaveGroupFinalConfirmation = false) }
     }
 
     fun onTransferMemberSelected(userId: java.util.UUID) {
@@ -310,9 +320,17 @@ class SettingsViewModel @Inject constructor(
         _uiState.update { it.copy(showDeleteAccountConfirmation = true) }
     }
 
+    fun onDeleteAccountFirstConfirmed() {
+        _uiState.update { it.copy(showDeleteAccountConfirmation = false, showDeleteAccountFinalConfirmation = true) }
+    }
+
+    fun onDeleteAccountFinalCancelled() {
+        _uiState.update { it.copy(showDeleteAccountFinalConfirmation = false) }
+    }
+
     fun onDeleteAccountConfirmed() {
         val providerType = _uiState.value.loginProviderType
-        _uiState.update { it.copy(showDeleteAccountConfirmation = false, isLoading = true) }
+        _uiState.update { it.copy(showDeleteAccountConfirmation = false, showDeleteAccountFinalConfirmation = false, isLoading = true) }
         viewModelScope.launch {
             try {
                 // 소셜 연결 해제 (iOS의 revokeClientSocialAccess와 동일, 실패해도 계정 삭제 진행)
@@ -332,7 +350,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun onDeleteAccountCancelled() {
-        _uiState.update { it.copy(showDeleteAccountConfirmation = false) }
+        _uiState.update { it.copy(showDeleteAccountConfirmation = false, showDeleteAccountFinalConfirmation = false) }
     }
 
     fun dismissError() {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -269,6 +269,10 @@
     <string name="settings_delete_account_desc">すべてのデータが削除され、復元できません</string>
     <string name="settings_delete_confirm">退会するとすべてのデータが削除されます。\nこの操作は元に戻せません。</string>
     <string name="settings_delete_btn">退会する</string>
+    <string name="settings_delete_final_title">最終確認です</string>
+    <string name="settings_delete_final_desc">本当にMongleとお別れしますか？\nこの選択は取り消せません。</string>
+    <string name="settings_delete_final_confirm">はい、退会します</string>
+    <string name="settings_delete_final_cancel">もう少し考えます</string>
     <string name="settings_account_section">アカウント</string>
     <string name="settings_preparing">準備中です</string>
     <string name="settings_preparing_desc">もうすぐ気分ヒストリーを確認できます</string>
@@ -302,6 +306,10 @@
     <string name="mgmt_leave_title">グループ退出</string>
     <string name="mgmt_leave_desc">グループを退出すると全ての回答記録の接続が解除されます。</string>
     <string name="mgmt_leave_btn">退出する</string>
+    <string name="group_leave_final_title">本当に退出しますか？</string>
+    <string name="group_leave_final_desc">この家族との毎日がここで途切れるかもしれません。\n戻るには再度招待が必要です。</string>
+    <string name="group_leave_final_confirm">はい、退出します</string>
+    <string name="group_leave_final_cancel">もう少しいます</string>
     <string name="mgmt_kick_title">%sさんを退出させますか？</string>
     <string name="mgmt_kick_desc">このメンバーはグループから除外されます。</string>
     <string name="mgmt_kick_btn">退出させる</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -269,6 +269,10 @@
     <string name="settings_delete_account_desc">모든 데이터가 삭제되며 복구할 수 없어요</string>
     <string name="settings_delete_confirm">탈퇴하면 모든 데이터가 삭제돼요.\n이 작업은 되돌릴 수 없어요.</string>
     <string name="settings_delete_btn">탈퇴하기</string>
+    <string name="settings_delete_final_title">마지막 확인이에요</string>
+    <string name="settings_delete_final_desc">정말 몽글과 작별하실 건가요?\n이 선택은 취소할 수 없어요.</string>
+    <string name="settings_delete_final_confirm">네, 탈퇴할게요</string>
+    <string name="settings_delete_final_cancel">더 생각해볼게요</string>
     <string name="settings_account_section">계정</string>
     <string name="settings_preparing">준비 중이에요</string>
     <string name="settings_preparing_desc">곧 기분 히스토리를 확인할 수 있어요</string>
@@ -302,6 +306,10 @@
     <string name="mgmt_leave_title">그룹 나가기</string>
     <string name="mgmt_leave_desc">그룹을 나가면 모든 멤버와의 답변 기록이 연결 해제됩니다.</string>
     <string name="mgmt_leave_btn">나가기</string>
+    <string name="group_leave_final_title">정말 나가실 건가요?</string>
+    <string name="group_leave_final_desc">이 가족과의 하루하루가 여기서 끊길 수 있어요.\n돌아오려면 다시 초대받아야 해요.</string>
+    <string name="group_leave_final_confirm">네, 나갈게요</string>
+    <string name="group_leave_final_cancel">더 있어볼게요</string>
     <string name="mgmt_kick_title">%s님을 내보낼까요?</string>
     <string name="mgmt_kick_desc">해당 멤버는 그룹에서 제외됩니다.</string>
     <string name="mgmt_kick_btn">내보내기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,6 +269,10 @@
     <string name="settings_delete_account_desc">All data will be deleted permanently</string>
     <string name="settings_delete_confirm">All data will be deleted.\nThis cannot be undone.</string>
     <string name="settings_delete_btn">Delete Account</string>
+    <string name="settings_delete_final_title">One last check</string>
+    <string name="settings_delete_final_desc">Are you sure you want to leave Mongle?\nThis choice cannot be undone.</string>
+    <string name="settings_delete_final_confirm">Yes, delete my account</string>
+    <string name="settings_delete_final_cancel">I\'ll think it over</string>
     <string name="settings_account_section">Account</string>
     <string name="settings_preparing">Coming Soon</string>
     <string name="settings_preparing_desc">Mood history is coming soon</string>
@@ -302,6 +306,10 @@
     <string name="mgmt_leave_title">Leave Group</string>
     <string name="mgmt_leave_desc">Leaving will disconnect all answer records.</string>
     <string name="mgmt_leave_btn">Leave</string>
+    <string name="group_leave_final_title">Are you sure?</string>
+    <string name="group_leave_final_desc">Your daily moments with this family end here.\nYou\'ll need a new invite to return.</string>
+    <string name="group_leave_final_confirm">Yes, leave</string>
+    <string name="group_leave_final_cancel">I\'ll stay for now</string>
     <string name="mgmt_kick_title">Remove %s?</string>
     <string name="mgmt_kick_desc">This member will be removed from the group.</string>
     <string name="mgmt_kick_btn">Remove</string>


### PR DESCRIPTION
## Jira
- [MG-28](https://ycompany.atlassian.net/browse/MG-28)
- 상위: [MG-24](https://ycompany.atlassian.net/browse/MG-24)

## Related
- iOS 대응 PR: [rrheon/Mongle#41](https://github.com/rrheon/Mongle/pull/41)
- MG-26 (Android 문구 전수 개선) — 차기 착수

## Summary
iOS MG-27과 1:1 매핑된 Android Compose 구현.
- 1차 확인에서 즉시 실행되던 파괴적 액션을 **2단계 확인(Context-aware)**으로 변경
- SettingsUiState에 `*FinalConfirmation` 필드 2개 추가
- ViewModel에 `*FirstConfirmed` / `*FinalCancelled` 함수 4개 추가
- Screen의 1차 팝업 `onPrimary` → `*FirstConfirmed` 교체, 2차 MonglePopup Dialog 추가
- strings.xml 3개 로케일 (default/ko/ja) 신규 키 8개

방장 72시간 체크·위임 후 나가기 로직은 그대로. 로그아웃은 단일 확인 유지.

## Test plan
- [ ] 계정 탈퇴: 1차 → 2차 → [네, 탈퇴할게요] → 실제 탈퇴
- [ ] 2차 [더 생각해볼게요] → 1차·2차 모두 닫힘
- [ ] 그룹 나가기 동일 플로우
- [ ] 방장 72시간 미경과 시 LeaveTooSoon 토스트 유지
- [ ] 방장 위임 플로우 정상 동작
- [ ] 로그아웃은 기존 1단계 확인
- [ ] ko / ja / en 각 로케일 문구 확인
- [ ] 다크·라이트 모드 확인

## Note
로컬 gradle 빌드는 `google-services.json` 패키지 미스매치(기존 환경 이슈)로 실행 불가. CI/실기기 빌드로 컴파일 검증 필요.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)