### PR TITLE
[MG-26] Android 팝업·토스트 문구 전수 개선 (8건)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,5 +77,15 @@
             </intent-filter>
         </service>
 
+        <!-- FCM 기본 알림 아이콘. 데이터 메시지는 MongleFcmService 가 직접 표시하지만,
+             notification payload 자동 처리 경로에서 launcher 아이콘으로 폴백되는 것을
+             방지하기 위해 명시. ic_notification 은 단색 벡터(흰색 실루엣) 기준. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_notification" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/mongle_primary" />
+
     </application>
 </manifest>

--- a/app/src/main/java/com/mongle/android/data/remote/ApiNotificationRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ApiNotificationRepository.kt
@@ -28,20 +28,24 @@ class ApiNotificationRepository @Inject constructor(
         }
     }
 
-    suspend fun getNotifications(limit: Int = 50): List<AppNotification> = safeCall {
-        api.getNotifications(limit).notifications.map { it.toApp() }
+    suspend fun getNotifications(limit: Int = 50, familyId: String? = null): List<AppNotification> = safeCall {
+        api.getNotifications(limit, familyId).notifications.map { it.toApp() }
     }
 
     suspend fun markAsRead(notificationId: String): AppNotification = safeCall {
         api.markNotificationRead(notificationId).toApp()
     }
 
-    suspend fun markAllAsRead(): Int = safeCall {
-        api.markAllNotificationsRead().count
+    suspend fun markAllAsRead(familyId: String? = null): Int = safeCall {
+        api.markAllNotificationsRead(familyId).count
     }
 
     suspend fun deleteNotification(notificationId: String) = safeCall {
         api.deleteNotification(notificationId)
+    }
+
+    suspend fun deleteAll(familyId: String? = null): Int = safeCall {
+        api.deleteAllNotifications(familyId).count
     }
 
     private fun NotificationDto.toApp() = AppNotification(

--- a/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
@@ -300,6 +300,11 @@ data class MarkAllReadResponse(
     val count: Int
 )
 
+@JsonClass(generateAdapter = true)
+data class DeleteAllNotificationsResponse(
+    val count: Int
+)
+
 // ── 재촉하기 ──────────────────────────────────────────
 
 @JsonClass(generateAdapter = true)
@@ -462,14 +467,24 @@ interface MongleApiService {
 
     // Notifications
     @GET("notifications")
-    suspend fun getNotifications(@Query("limit") limit: Int = 50): GetNotificationsResponse
+    suspend fun getNotifications(
+        @Query("limit") limit: Int = 50,
+        @Query("group_id") groupId: String? = null
+    ): GetNotificationsResponse
 
     @PATCH("notifications/{notificationId}/read")
     suspend fun markNotificationRead(@Path("notificationId") notificationId: String): NotificationDto
 
     @PATCH("notifications/read-all")
-    suspend fun markAllNotificationsRead(): MarkAllReadResponse
+    suspend fun markAllNotificationsRead(
+        @Query("group_id") groupId: String? = null
+    ): MarkAllReadResponse
 
     @DELETE("notifications/{notificationId}")
     suspend fun deleteNotification(@Path("notificationId") notificationId: String)
+
+    @DELETE("notifications")
+    suspend fun deleteAllNotifications(
+        @Query("group_id") groupId: String? = null
+    ): DeleteAllNotificationsResponse
 }

--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
@@ -100,9 +100,11 @@ fun NotificationScreen(
 
     BackHandler { onBack() }
 
-    // 화면 진입/복귀 시 최신 알림 재로딩 (FCM 푸시 수신 후 즉시 반영)
-    LaunchedEffect(Unit) {
-        viewModel.loadNotifications()
+    // 화면 진입/복귀 시 최신 알림 재로딩 (FCM 푸시 수신 후 즉시 반영).
+    // currentFamilyId 를 ViewModel scope 로 설정 → 이후 markAllAsRead/deleteAll 이
+    // 자동으로 해당 그룹 스코프만 처리한다.
+    LaunchedEffect(currentFamilyId) {
+        viewModel.loadNotifications(currentFamilyId?.toString())
     }
 
     LaunchedEffect(uiState.errorMessage) {
@@ -195,11 +197,10 @@ fun NotificationScreen(
                 }
             }
             else -> {
-                // 현재 그룹 필터 적용 (familyId 미지정 알림은 그룹 무관하게 항상 노출)
+                // 서버가 이미 group_id 로 필터링해서 내려주지만, 안전망으로 클라도 필터.
+                // 각 그룹 화면에서는 해당 그룹 알림만 노출 — 그룹 무관(familyId==null) 알림도 제외.
                 val filtered = if (currentFamilyId != null) {
-                    uiState.notifications.filter {
-                        it.familyId == null || it.familyId == currentFamilyId.toString()
-                    }
+                    uiState.notifications.filter { it.familyId == currentFamilyId.toString() }
                 } else {
                     uiState.notifications
                 }
@@ -227,7 +228,7 @@ fun NotificationScreen(
                 } else {
                     PullToRefreshBox(
                         isRefreshing = uiState.isLoading,
-                        onRefresh = { viewModel.loadNotifications() },
+                        onRefresh = { viewModel.loadNotifications(currentFamilyId?.toString()) },
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(paddingValues)

--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationViewModel.kt
@@ -30,15 +30,29 @@ class NotificationViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(NotificationUiState())
     val uiState: StateFlow<NotificationUiState> = _uiState.asStateFlow()
 
+    /**
+     * 알림 스코프.
+     * - null: 그룹선택 화면에서 진입한 전역 목록
+     * - not null: 특정 그룹 내부에서 진입한 그룹 한정 목록
+     *
+     * loadNotifications / markAllAsRead / deleteAll 이 이 스코프를 서버에 전달한다.
+     */
+    private var scopeFamilyId: String? = null
+
     init {
+        // ViewModel 생성 즉시 기본 로드(scopeFamilyId=null, 전역).
+        // Screen 의 LaunchedEffect(currentFamilyId) 가 이후 올바른 스코프로 재호출한다.
+        // 딥링크·푸시 탭 → 재진입 경로에서 Compose 의 LaunchedEffect key 가 변하지 않아
+        // 재실행되지 않는 케이스를 커버하기 위한 안전망.
         loadNotifications()
     }
 
-    fun loadNotifications() {
+    fun loadNotifications(familyId: String? = scopeFamilyId) {
+        scopeFamilyId = familyId
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
             try {
-                val items = notificationRepository.getNotifications()
+                val items = notificationRepository.getNotifications(familyId = familyId)
                 _uiState.update { it.copy(isLoading = false, notifications = items) }
             } catch (e: Exception) {
                 _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
@@ -61,12 +75,17 @@ class NotificationViewModel @Inject constructor(
     }
 
     fun onMarkAllAsRead() {
+        val familyId = scopeFamilyId
         _uiState.update { state ->
-            state.copy(notifications = state.notifications.map { it.copy(isRead = true) })
+            // 스코프가 지정되어 있으면 해당 그룹 알림만, 아니면 전체를 읽음 처리
+            val updated = state.notifications.map { n ->
+                if (familyId == null || n.familyId == familyId) n.copy(isRead = true) else n
+            }
+            state.copy(notifications = updated)
         }
         viewModelScope.launch {
             withContext(NonCancellable) {
-                runCatching { notificationRepository.markAllAsRead() }
+                runCatching { notificationRepository.markAllAsRead(familyId) }
             }
         }
     }
@@ -88,8 +107,10 @@ class NotificationViewModel @Inject constructor(
      * - familyId == null: 전체 알림 제거 (그룹 선택 화면에서 진입한 경우)
      * - familyId != null: 해당 그룹에 속한 알림만 제거. 그룹 무관(familyId == null)
      *   알림은 다른 그룹에서도 계속 노출되어야 하므로 남겨둔다.
+     *
+     * 파라미터 미지정 시 현재 스코프(scopeFamilyId)를 사용한다.
      */
-    fun onDeleteAll(familyId: String? = null) {
+    fun onDeleteAll(familyId: String? = scopeFamilyId) {
         val current = _uiState.value.notifications
         val toDelete = if (familyId == null) {
             current
@@ -99,14 +120,12 @@ class NotificationViewModel @Inject constructor(
         if (toDelete.isEmpty()) return
         val remaining = current - toDelete.toSet()
         _uiState.update { it.copy(notifications = remaining) }
-        // 사용자가 모두제거 직후 다른 화면으로 이동하면 viewModelScope가 취소되어
-        // 일부 삭제 API가 실행되지 못해, 재진입 시 서버에서 알림이 다시 내려오는 문제가 있었다.
-        // NonCancellable 컨텍스트로 감싸 모든 삭제 호출이 끝까지 수행되도록 한다.
+        // 서버 일괄 삭제 API 사용 — 이전에는 개별 삭제를 반복 호출했지만
+        // 서버에 DELETE /notifications?group_id= 가 추가되어 1회 호출로 처리한다.
+        // NonCancellable 로 화면 전환 시에도 요청 완료 보장.
         viewModelScope.launch {
             withContext(NonCancellable) {
-                toDelete.forEach { n ->
-                    runCatching { notificationRepository.deleteNotification(n.id) }
-                }
+                runCatching { notificationRepository.deleteAll(familyId) }
             }
         }
     }

--- a/app/src/main/java/com/mongle/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/settings/SettingsScreen.kt
@@ -231,7 +231,9 @@ fun SettingsScreen(
                     onKickMemberConfirmed = viewModel::onKickMemberConfirmed,
                     onKickMemberCancelled = viewModel::onKickMemberCancelled,
                     onLeaveGroupTapped = viewModel::onLeaveGroupTapped,
+                    onLeaveGroupFirstConfirmed = viewModel::onLeaveGroupFirstConfirmed,
                     onLeaveGroupConfirmed = viewModel::onLeaveGroupConfirmed,
+                    onLeaveGroupFinalCancelled = viewModel::onLeaveGroupFinalCancelled,
                     onLeaveGroupCancelled = viewModel::onLeaveGroupCancelled
                 )
             }
@@ -254,7 +256,9 @@ fun SettingsScreen(
                     onLogoutConfirmed = viewModel::onLogoutConfirmed,
                     onLogoutCancelled = viewModel::onLogoutCancelled,
                     onDeleteAccountTapped = viewModel::onDeleteAccountTapped,
+                    onDeleteAccountFirstConfirmed = viewModel::onDeleteAccountFirstConfirmed,
                     onDeleteAccountConfirmed = viewModel::onDeleteAccountConfirmed,
+                    onDeleteAccountFinalCancelled = viewModel::onDeleteAccountFinalCancelled,
                     onDeleteAccountCancelled = viewModel::onDeleteAccountCancelled
                 )
             }
@@ -738,7 +742,9 @@ private fun GroupManagementScreen(
     onKickMemberConfirmed: () -> Unit,
     onKickMemberCancelled: () -> Unit,
     onLeaveGroupTapped: () -> Unit,
+    onLeaveGroupFirstConfirmed: () -> Unit,
     onLeaveGroupConfirmed: () -> Unit,
+    onLeaveGroupFinalCancelled: () -> Unit,
     onLeaveGroupCancelled: () -> Unit
 ) {
     val context = LocalContext.current
@@ -761,7 +767,7 @@ private fun GroupManagementScreen(
         }
     }
 
-    // 그룹 나가기 확인
+    // 그룹 나가기 1차 확인
     if (uiState.showLeaveGroupConfirmation) {
         Dialog(
             onDismissRequest = onLeaveGroupCancelled,
@@ -771,9 +777,27 @@ private fun GroupManagementScreen(
                 title = stringResource(R.string.mgmt_leave_title),
                 description = stringResource(R.string.mgmt_leave_desc),
                 primaryLabel = stringResource(R.string.mgmt_leave_btn),
-                onPrimary = onLeaveGroupConfirmed,
+                onPrimary = onLeaveGroupFirstConfirmed,
                 secondaryLabel = stringResource(R.string.common_cancel),
                 onSecondary = onLeaveGroupCancelled,
+                isDestructive = true
+            )
+        }
+    }
+
+    // 그룹 나가기 2차 확인 (Context-aware final confirm)
+    if (uiState.showLeaveGroupFinalConfirmation) {
+        Dialog(
+            onDismissRequest = onLeaveGroupFinalCancelled,
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            MonglePopup(
+                title = stringResource(R.string.group_leave_final_title),
+                description = stringResource(R.string.group_leave_final_desc),
+                primaryLabel = stringResource(R.string.group_leave_final_confirm),
+                onPrimary = onLeaveGroupConfirmed,
+                secondaryLabel = stringResource(R.string.group_leave_final_cancel),
+                onSecondary = onLeaveGroupFinalCancelled,
                 isDestructive = true
             )
         }
@@ -1037,7 +1061,9 @@ private fun AccountManagementScreen(
     onLogoutConfirmed: () -> Unit,
     onLogoutCancelled: () -> Unit,
     onDeleteAccountTapped: () -> Unit,
+    onDeleteAccountFirstConfirmed: () -> Unit,
     onDeleteAccountConfirmed: () -> Unit,
+    onDeleteAccountFinalCancelled: () -> Unit,
     onDeleteAccountCancelled: () -> Unit
 ) {
     // 로그아웃 확인 다이얼로그
@@ -1058,7 +1084,7 @@ private fun AccountManagementScreen(
         }
     }
 
-    // 계정 탈퇴 확인 다이얼로그
+    // 계정 탈퇴 1차 확인 다이얼로그
     if (uiState.showDeleteAccountConfirmation) {
         Dialog(
             onDismissRequest = onDeleteAccountCancelled,
@@ -1068,9 +1094,27 @@ private fun AccountManagementScreen(
                 title = stringResource(R.string.settings_delete_account),
                 description = stringResource(R.string.settings_delete_confirm),
                 primaryLabel = stringResource(R.string.settings_delete_btn),
-                onPrimary = onDeleteAccountConfirmed,
+                onPrimary = onDeleteAccountFirstConfirmed,
                 secondaryLabel = stringResource(R.string.common_cancel),
                 onSecondary = onDeleteAccountCancelled,
+                isDestructive = true
+            )
+        }
+    }
+
+    // 계정 탈퇴 2차 확인 다이얼로그 (Context-aware final confirm)
+    if (uiState.showDeleteAccountFinalConfirmation) {
+        Dialog(
+            onDismissRequest = onDeleteAccountFinalCancelled,
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            MonglePopup(
+                title = stringResource(R.string.settings_delete_final_title),
+                description = stringResource(R.string.settings_delete_final_desc),
+                primaryLabel = stringResource(R.string.settings_delete_final_confirm),
+                onPrimary = onDeleteAccountConfirmed,
+                secondaryLabel = stringResource(R.string.settings_delete_final_cancel),
+                onSecondary = onDeleteAccountFinalCancelled,
                 isDestructive = true
             )
         }

--- a/app/src/main/java/com/mongle/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/settings/SettingsViewModel.kt
@@ -34,7 +34,9 @@ data class SettingsUiState(
     val isLoading: Boolean = false,
     val showLogoutConfirmation: Boolean = false,
     val showDeleteAccountConfirmation: Boolean = false,
+    val showDeleteAccountFinalConfirmation: Boolean = false,
     val showLeaveGroupConfirmation: Boolean = false,
+    val showLeaveGroupFinalConfirmation: Boolean = false,
     val showTransferSheet: Boolean = false,
     val selectedTransferMemberId: java.util.UUID? = null,
     val showKickConfirmation: Boolean = false,
@@ -208,9 +210,17 @@ class SettingsViewModel @Inject constructor(
         _uiState.update { it.copy(showLeaveGroupConfirmation = true) }
     }
 
+    fun onLeaveGroupFirstConfirmed() {
+        _uiState.update { it.copy(showLeaveGroupConfirmation = false, showLeaveGroupFinalConfirmation = true) }
+    }
+
+    fun onLeaveGroupFinalCancelled() {
+        _uiState.update { it.copy(showLeaveGroupFinalConfirmation = false) }
+    }
+
     fun onLeaveGroupConfirmed() {
         val state = _uiState.value
-        _uiState.update { it.copy(showLeaveGroupConfirmation = false) }
+        _uiState.update { it.copy(showLeaveGroupConfirmation = false, showLeaveGroupFinalConfirmation = false) }
 
         if (state.isOwner && state.transferCandidates.isNotEmpty()) {
             // 방장이고 다른 멤버가 있으면 위임 시트 표시
@@ -234,7 +244,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun onLeaveGroupCancelled() {
-        _uiState.update { it.copy(showLeaveGroupConfirmation = false) }
+        _uiState.update { it.copy(showLeaveGroupConfirmation = false, showLeaveGroupFinalConfirmation = false) }
     }
 
     fun onTransferMemberSelected(userId: java.util.UUID) {
@@ -310,9 +320,17 @@ class SettingsViewModel @Inject constructor(
         _uiState.update { it.copy(showDeleteAccountConfirmation = true) }
     }
 
+    fun onDeleteAccountFirstConfirmed() {
+        _uiState.update { it.copy(showDeleteAccountConfirmation = false, showDeleteAccountFinalConfirmation = true) }
+    }
+
+    fun onDeleteAccountFinalCancelled() {
+        _uiState.update { it.copy(showDeleteAccountFinalConfirmation = false) }
+    }
+
     fun onDeleteAccountConfirmed() {
         val providerType = _uiState.value.loginProviderType
-        _uiState.update { it.copy(showDeleteAccountConfirmation = false, isLoading = true) }
+        _uiState.update { it.copy(showDeleteAccountConfirmation = false, showDeleteAccountFinalConfirmation = false, isLoading = true) }
         viewModelScope.launch {
             try {
                 // 소셜 연결 해제 (iOS의 revokeClientSocialAccess와 동일, 실패해도 계정 삭제 진행)
@@ -332,7 +350,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun onDeleteAccountCancelled() {
-        _uiState.update { it.copy(showDeleteAccountConfirmation = false) }
+        _uiState.update { it.copy(showDeleteAccountConfirmation = false, showDeleteAccountFinalConfirmation = false) }
     }
 
     fun dismissError() {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -269,6 +269,10 @@
     <string name="settings_delete_account_desc">すべてのデータが削除され、復元できません</string>
     <string name="settings_delete_confirm">退会するとすべてのデータが削除されます。\nこの操作は元に戻せません。</string>
     <string name="settings_delete_btn">退会する</string>
+    <string name="settings_delete_final_title">最終確認です</string>
+    <string name="settings_delete_final_desc">本当にMongleとお別れしますか？\nこの選択は取り消せません。</string>
+    <string name="settings_delete_final_confirm">はい、退会します</string>
+    <string name="settings_delete_final_cancel">もう少し考えます</string>
     <string name="settings_account_section">アカウント</string>
     <string name="settings_preparing">準備中です</string>
     <string name="settings_preparing_desc">もうすぐ気分ヒストリーを確認できます</string>
@@ -302,6 +306,10 @@
     <string name="mgmt_leave_title">グループ退出</string>
     <string name="mgmt_leave_desc">グループを退出すると全ての回答記録の接続が解除されます。</string>
     <string name="mgmt_leave_btn">退出する</string>
+    <string name="group_leave_final_title">本当に退出しますか？</string>
+    <string name="group_leave_final_desc">この家族との毎日がここで途切れるかもしれません。\n戻るには再度招待が必要です。</string>
+    <string name="group_leave_final_confirm">はい、退出します</string>
+    <string name="group_leave_final_cancel">もう少しいます</string>
     <string name="mgmt_kick_title">%sさんを退出させますか？</string>
     <string name="mgmt_kick_desc">このメンバーはグループから除外されます。</string>
     <string name="mgmt_kick_btn">退出させる</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -63,7 +63,7 @@
     <string name="onboarding_group_desc">家族、友達、カップルなど\n一緒にしたい人を招待しましょう</string>
     <string name="onboarding_question_title">毎日一緒に\n気持ちを分かち合おう</string>
     <string name="onboarding_question_desc">毎日新しい質問に答えて\nお互いの気持ちを覗いてみましょう</string>
-    <string name="onboarding_sample_group">私たちのグループ 🩷</string>
+    <string name="onboarding_sample_group">私たちのグループ</string>
     <string name="onboarding_sample_question">今日あなたを笑顔にしたものは何ですか？</string>
     <string name="onboarding_today_question">今日の質問</string>
     <string name="onboarding_start">はじめる</string>
@@ -207,7 +207,7 @@
     <string name="group_code_placeholder">招待コードを入力してください</string>
     <string name="group_code_hint">大文字と数字で構成されたコードです</string>
     <string name="group_join_btn">参加する</string>
-    <string name="group_created_title">スペースが作成されました！🎉</string>
+    <string name="group_created_title">スペースが作成されました！</string>
     <string name="group_created_desc">下のコードやリンクで友達を招待してみましょう</string>
     <string name="group_invite_code">招待コード</string>
     <string name="group_invite_link">招待リンク</string>
@@ -217,14 +217,14 @@
     <string name="group_mongle_title">モングル</string>
 
     <!-- Notification Permission -->
-    <string name="perm_notif_title">通知を許可してください 🔔</string>
+    <string name="perm_notif_title">通知を許可してください</string>
     <string name="perm_notif_desc">グループのお知らせを見逃さないようにしましょう</string>
     <string name="perm_notif_answer">メンバーが回答した時</string>
     <string name="perm_notif_nudge">催促通知を受けた時</string>
     <string name="perm_notif_question">新しい質問通知</string>
     <string name="perm_notif_allow">許可する</string>
     <string name="perm_notif_later">あとで</string>
-    <string name="perm_dnd_title">おやすみ時間 🌙</string>
+    <string name="perm_dnd_title">おやすみ時間</string>
     <string name="perm_dnd_desc">就寝時間には通知を受けません</string>
     <string name="perm_dnd_time">午後10:00 - 午前8:00</string>
     <string name="perm_dnd_use">使用する</string>
@@ -304,14 +304,14 @@
     <string name="mgmt_invite_desc">招待コードやリンクを共有してメンバーを招待しましょう</string>
     <string name="mgmt_leave">グループを退出</string>
     <string name="mgmt_leave_title">グループ退出</string>
-    <string name="mgmt_leave_desc">グループを退出すると全ての回答記録の接続が解除されます。</string>
+    <string name="mgmt_leave_desc">グループを退出するとメンバーとの回答記録の接続が解除されます。</string>
     <string name="mgmt_leave_btn">退出する</string>
     <string name="group_leave_final_title">本当に退出しますか？</string>
     <string name="group_leave_final_desc">この家族との毎日がここで途切れるかもしれません。\n戻るには再度招待が必要です。</string>
     <string name="group_leave_final_confirm">はい、退出します</string>
     <string name="group_leave_final_cancel">もう少しいます</string>
     <string name="mgmt_kick_title">%sさんを退出させますか？</string>
-    <string name="mgmt_kick_desc">このメンバーはグループから除外されます。</string>
+    <string name="mgmt_kick_desc">このメンバーはグループから退出します。</string>
     <string name="mgmt_kick_btn">退出させる</string>
     <string name="mgmt_transfer_title">管理者委任</string>
     <string name="mgmt_transfer_desc">グループを退出する前に管理者を委任するメンバーを選択してください。</string>
@@ -343,7 +343,7 @@
     <string name="toast_edit">回答を修正しました！</string>
     <string name="toast_answer">気持ちを残しました！</string>
     <string name="toast_group_left">グループを退出しました</string>
-    <string name="toast_code_copied">招待コードがコピーされました</string>
+    <string name="toast_code_copied">招待コードをコピーしました！</string>
     <string name="toast_max_groups">グループは最大3つまで作成できます</string>
     <string name="toast_already_member">すでに参加しているグループです</string>
     <string name="toast_invalid_code">招待コードを再確認してください</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -269,6 +269,10 @@
     <string name="settings_delete_account_desc">모든 데이터가 삭제되며 복구할 수 없어요</string>
     <string name="settings_delete_confirm">탈퇴하면 모든 데이터가 삭제돼요.\n이 작업은 되돌릴 수 없어요.</string>
     <string name="settings_delete_btn">탈퇴하기</string>
+    <string name="settings_delete_final_title">마지막 확인이에요</string>
+    <string name="settings_delete_final_desc">정말 몽글과 작별하실 건가요?\n이 선택은 취소할 수 없어요.</string>
+    <string name="settings_delete_final_confirm">네, 탈퇴할게요</string>
+    <string name="settings_delete_final_cancel">더 생각해볼게요</string>
     <string name="settings_account_section">계정</string>
     <string name="settings_preparing">준비 중이에요</string>
     <string name="settings_preparing_desc">곧 기분 히스토리를 확인할 수 있어요</string>
@@ -302,6 +306,10 @@
     <string name="mgmt_leave_title">그룹 나가기</string>
     <string name="mgmt_leave_desc">그룹을 나가면 모든 멤버와의 답변 기록이 연결 해제됩니다.</string>
     <string name="mgmt_leave_btn">나가기</string>
+    <string name="group_leave_final_title">정말 나가실 건가요?</string>
+    <string name="group_leave_final_desc">이 가족과의 하루하루가 여기서 끊길 수 있어요.\n돌아오려면 다시 초대받아야 해요.</string>
+    <string name="group_leave_final_confirm">네, 나갈게요</string>
+    <string name="group_leave_final_cancel">더 있어볼게요</string>
     <string name="mgmt_kick_title">%s님을 내보낼까요?</string>
     <string name="mgmt_kick_desc">해당 멤버는 그룹에서 제외됩니다.</string>
     <string name="mgmt_kick_btn">내보내기</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -63,7 +63,7 @@
     <string name="onboarding_group_desc">가족, 친구, 커플 등\n함께하고 싶은 사람들을 초대해요</string>
     <string name="onboarding_question_title">매일 함께\n마음을 나눠요</string>
     <string name="onboarding_question_desc">매일 새로운 질문에 답하고\n서로의 마음을 들여다보세요</string>
-    <string name="onboarding_sample_group">우리 그룹 🩷</string>
+    <string name="onboarding_sample_group">우리 그룹</string>
     <string name="onboarding_sample_question">오늘 당신을 웃게 한 건 무엇인가요?</string>
     <string name="onboarding_today_question">오늘의 질문</string>
     <string name="onboarding_start">시작하기</string>
@@ -207,7 +207,7 @@
     <string name="group_code_placeholder">초대 코드를 입력해주세요</string>
     <string name="group_code_hint">대문자와 숫자로 이루어진 코드에요</string>
     <string name="group_join_btn">참여하기</string>
-    <string name="group_created_title">공간이 만들어졌어요! 🎉</string>
+    <string name="group_created_title">공간이 만들어졌어요!</string>
     <string name="group_created_desc">아래 코드나 링크로 친구를 초대해보세요</string>
     <string name="group_invite_code">초대 코드</string>
     <string name="group_invite_link">초대 링크</string>
@@ -217,14 +217,14 @@
     <string name="group_mongle_title">몽글</string>
 
     <!-- Notification Permission -->
-    <string name="perm_notif_title">알림을 허용해 주세요 🔔</string>
+    <string name="perm_notif_title">알림을 허용해 주세요</string>
     <string name="perm_notif_desc">그룹 소식을 놓치지 않을 수 있어요</string>
     <string name="perm_notif_answer">멤버가 답변했을 때</string>
     <string name="perm_notif_nudge">재촉 알림을 받았을 때</string>
     <string name="perm_notif_question">새 질문 알림</string>
     <string name="perm_notif_allow">허용하기</string>
     <string name="perm_notif_later">나중에</string>
-    <string name="perm_dnd_title">방해 금지 시간 🌙</string>
+    <string name="perm_dnd_title">방해 금지 시간</string>
     <string name="perm_dnd_desc">취침 시간에는 알림을 받지 않아요</string>
     <string name="perm_dnd_time">오후 10:00 - 오전 8:00</string>
     <string name="perm_dnd_use">사용하기</string>
@@ -304,14 +304,14 @@
     <string name="mgmt_invite_desc">초대 코드나 링크를 공유해 멤버를 초대하세요</string>
     <string name="mgmt_leave">그룹 나가기</string>
     <string name="mgmt_leave_title">그룹 나가기</string>
-    <string name="mgmt_leave_desc">그룹을 나가면 모든 멤버와의 답변 기록이 연결 해제됩니다.</string>
+    <string name="mgmt_leave_desc">그룹을 나가면 멤버와의 답변 기록 연결이 해제돼요.</string>
     <string name="mgmt_leave_btn">나가기</string>
     <string name="group_leave_final_title">정말 나가실 건가요?</string>
     <string name="group_leave_final_desc">이 가족과의 하루하루가 여기서 끊길 수 있어요.\n돌아오려면 다시 초대받아야 해요.</string>
     <string name="group_leave_final_confirm">네, 나갈게요</string>
     <string name="group_leave_final_cancel">더 있어볼게요</string>
     <string name="mgmt_kick_title">%s님을 내보낼까요?</string>
-    <string name="mgmt_kick_desc">해당 멤버는 그룹에서 제외됩니다.</string>
+    <string name="mgmt_kick_desc">이 멤버는 그룹에서 나가게 돼요.</string>
     <string name="mgmt_kick_btn">내보내기</string>
     <string name="mgmt_transfer_title">방장 위임</string>
     <string name="mgmt_transfer_desc">그룹을 나가기 전에 방장을 위임할 멤버를 선택해주세요.</string>
@@ -343,7 +343,7 @@
     <string name="toast_edit">답변을 수정했어요!</string>
     <string name="toast_answer">마음을 남겼어요!</string>
     <string name="toast_group_left">그룹에서 나왔어요</string>
-    <string name="toast_code_copied">초대 코드가 복사되었습니다</string>
+    <string name="toast_code_copied">초대 코드를 복사했어요</string>
     <string name="toast_max_groups">그룹은 최대 3개까지 만들 수 있어요</string>
     <string name="toast_already_member">이미 속해있는 그룹이에요</string>
     <string name="toast_invalid_code">초대코드를 다시 확인해주세요</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="mongle_primary">#FF4CAF50</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,7 +63,7 @@
     <string name="onboarding_group_desc">Invite family, friends, couples\nand anyone you want</string>
     <string name="onboarding_question_title">Share your\nfeelings daily</string>
     <string name="onboarding_question_desc">Answer new questions daily\nand peek into each other\'s hearts</string>
-    <string name="onboarding_sample_group">My Group 🩷</string>
+    <string name="onboarding_sample_group">My Group</string>
     <string name="onboarding_sample_question">What made you smile today?</string>
     <string name="onboarding_today_question">Today\'s Question</string>
     <string name="onboarding_start">Get Started</string>
@@ -207,7 +207,7 @@
     <string name="group_code_placeholder">Enter invite code</string>
     <string name="group_code_hint">Code consists of uppercase letters and numbers</string>
     <string name="group_join_btn">Join</string>
-    <string name="group_created_title">Space created! 🎉</string>
+    <string name="group_created_title">Space created!</string>
     <string name="group_created_desc">Invite friends with the code or link below</string>
     <string name="group_invite_code">Invite Code</string>
     <string name="group_invite_link">Invite Link</string>
@@ -217,14 +217,14 @@
     <string name="group_mongle_title">Mongle</string>
 
     <!-- Notification Permission -->
-    <string name="perm_notif_title">Allow notifications 🔔</string>
+    <string name="perm_notif_title">Allow notifications</string>
     <string name="perm_notif_desc">Don\'t miss updates from your group</string>
     <string name="perm_notif_answer">When a member answers</string>
     <string name="perm_notif_nudge">When you receive a nudge</string>
     <string name="perm_notif_question">New question notification</string>
     <string name="perm_notif_allow">Allow</string>
     <string name="perm_notif_later">Later</string>
-    <string name="perm_dnd_title">Do Not Disturb 🌙</string>
+    <string name="perm_dnd_title">Do Not Disturb</string>
     <string name="perm_dnd_desc">No notifications during bedtime</string>
     <string name="perm_dnd_time">10:00 PM - 8:00 AM</string>
     <string name="perm_dnd_use">Enable</string>
@@ -304,14 +304,14 @@
     <string name="mgmt_invite_desc">Share invite code or link</string>
     <string name="mgmt_leave">Leave Group</string>
     <string name="mgmt_leave_title">Leave Group</string>
-    <string name="mgmt_leave_desc">Leaving will disconnect all answer records.</string>
+    <string name="mgmt_leave_desc">Leaving disconnects your answer records with members.</string>
     <string name="mgmt_leave_btn">Leave</string>
     <string name="group_leave_final_title">Are you sure?</string>
     <string name="group_leave_final_desc">Your daily moments with this family end here.\nYou\'ll need a new invite to return.</string>
     <string name="group_leave_final_confirm">Yes, leave</string>
     <string name="group_leave_final_cancel">I\'ll stay for now</string>
     <string name="mgmt_kick_title">Remove %s?</string>
-    <string name="mgmt_kick_desc">This member will be removed from the group.</string>
+    <string name="mgmt_kick_desc">This member will leave the group.</string>
     <string name="mgmt_kick_btn">Remove</string>
     <string name="mgmt_transfer_title">Transfer Admin</string>
     <string name="mgmt_transfer_desc">Select a member to transfer admin rights before leaving.</string>
@@ -341,9 +341,9 @@
     <string name="toast_write">Your question has been registered!</string>
     <string name="toast_nudge">Nudge sent!</string>
     <string name="toast_edit">Answer edited!</string>
-    <string name="toast_answer">Heart left!</string>
+    <string name="toast_answer">Heart earned!</string>
     <string name="toast_group_left">Left the group</string>
-    <string name="toast_code_copied">Invite code copied</string>
+    <string name="toast_code_copied">Invite code copied!</string>
     <string name="toast_max_groups">You can create up to 3 groups</string>
     <string name="toast_already_member">Already a member of this group</string>
     <string name="toast_invalid_code">Please check the invite code</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,6 +269,10 @@
     <string name="settings_delete_account_desc">All data will be deleted permanently</string>
     <string name="settings_delete_confirm">All data will be deleted.\nThis cannot be undone.</string>
     <string name="settings_delete_btn">Delete Account</string>
+    <string name="settings_delete_final_title">One last check</string>
+    <string name="settings_delete_final_desc">Are you sure you want to leave Mongle?\nThis choice cannot be undone.</string>
+    <string name="settings_delete_final_confirm">Yes, delete my account</string>
+    <string name="settings_delete_final_cancel">I\'ll think it over</string>
     <string name="settings_account_section">Account</string>
     <string name="settings_preparing">Coming Soon</string>
     <string name="settings_preparing_desc">Mood history is coming soon</string>
@@ -302,6 +306,10 @@
     <string name="mgmt_leave_title">Leave Group</string>
     <string name="mgmt_leave_desc">Leaving will disconnect all answer records.</string>
     <string name="mgmt_leave_btn">Leave</string>
+    <string name="group_leave_final_title">Are you sure?</string>
+    <string name="group_leave_final_desc">Your daily moments with this family end here.\nYou\'ll need a new invite to return.</string>
+    <string name="group_leave_final_confirm">Yes, leave</string>
+    <string name="group_leave_final_cancel">I\'ll stay for now</string>
     <string name="mgmt_kick_title">Remove %s?</string>
     <string name="mgmt_kick_desc">This member will be removed from the group.</string>
     <string name="mgmt_kick_btn">Remove</string>


### PR DESCRIPTION
## Jira
- [MG-26](https://ycompany.atlassian.net/browse/MG-26)
- 상위: [MG-24](https://ycompany.atlassian.net/browse/MG-24)

## Related
- **머지 순서**: MG-28 PR(#11) 기반으로 분기 → **#11 머지 후 본 PR rebase 필요**
- iOS 대응: [rrheon/Mongle#43](https://github.com/rrheon/Mongle/pull/43)

## Summary
iOS MG-25와 동일 톤을 Android strings.xml 3개 로케일(default/ko/ja)에 반영:

- **이모지 제거** 4건: `onboarding_sample_group`, `group_created_title`, `perm_notif_title`, `perm_dnd_title`
- **톤 개선** 3건: `mgmt_leave_desc`, `mgmt_kick_desc`, `toast_code_copied`
- **영문 자연어** 1건: `toast_answer` "Heart left!" → "Heart earned!"

`HeartEarnedPopup` 하드코딩 리소스화는 후속 티켓으로 분리 (Q3 결정).

## Test plan
- [ ] 온보딩 샘플 그룹명 / 그룹 생성 완료 / 알림·방해금지 권한 팝업 이모지 제거 확인
- [ ] 그룹 관리 → 그룹 나가기 1차 팝업 문구 자연스러움
- [ ] 멤버 내보내기 팝업 문구
- [ ] 초대 코드 복사 토스트
- [ ] 답변 제출 후 영문 "Heart earned!" 토스트
- [ ] ko / ja / en 로케일 동기화 확인

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)