### PR TITLE
fix(auth): 토큰/세션 race 안정화 — install sentinel·session 신호·login alert (MG-82)

### DIFF
--- a/app/src/main/java/com/mongle/android/MongleApplication.kt
+++ b/app/src/main/java/com/mongle/android/MongleApplication.kt
@@ -2,14 +2,27 @@ package com.mongle.android
 import com.ycompany.Monggle.BuildConfig
 
 import android.app.Application
+import android.content.Context
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
+
+private const val APP_PREFS_NAME = "mongle_app_prefs"
+private const val INSTALL_SENTINEL_KEY = "mongle.installSentinel"
 
 @HiltAndroidApp
 class MongleApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // 재설치 감지 — 일부 환경에서는 SharedPreferences 가 즉시 비워지지 않을 수 있어
+        // 신규 설치 시점에 이전 사용자 토큰/하트 마커/FCM 토큰을 명시 폐기한다.
+        val appPrefs = getSharedPreferences(APP_PREFS_NAME, Context.MODE_PRIVATE)
+        if (!appPrefs.getBoolean(INSTALL_SENTINEL_KEY, false)) {
+            getSharedPreferences("mongle_auth", Context.MODE_PRIVATE).edit().clear().apply()
+            getSharedPreferences("mongle_heart", Context.MODE_PRIVATE).edit().clear().apply()
+            getSharedPreferences("fcm", Context.MODE_PRIVATE).edit().clear().apply()
+            appPrefs.edit().putBoolean(INSTALL_SENTINEL_KEY, true).apply()
+        }
         KakaoSdk.init(this, BuildConfig.KAKAO_APP_KEY)
         // AdMob 초기화는 ConsentManager 가 MainActivity.onCreate 에서 수행한다.
         // (UMP 동의 폼은 Activity context 를 필요로 하므로 Application 에서 초기화하지 않음)

--- a/app/src/main/java/com/mongle/android/data/remote/TokenAuthenticator.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/TokenAuthenticator.kt
@@ -50,8 +50,15 @@ class TokenAuthenticator @Inject constructor(
             return null
         }
 
+        // 첫 설치 직후 또는 로그아웃 직후처럼 refresh 토큰이 SharedPreferences 에 한 번도
+        // 들어간 적 없는 상태에서는 sessionExpired 신호를 발화하지 않는다.
+        // 발화하면 RootViewModel 이 "세션 만료"로 라우팅돼 사용자에게 불필요한 재로그인 안내가 노출됨.
         val refreshToken = prefs.getString(AUTH_KEY_REFRESH_TOKEN, null) ?: run {
-            notifyAndClear()
+            if (prefs.contains(AUTH_KEY_REFRESH_TOKEN)) {
+                notifyAndClear()
+            } else {
+                prefs.edit().clear().apply()
+            }
             return null
         }
 

--- a/app/src/main/java/com/mongle/android/ui/emailauth/EmailLoginScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/emailauth/EmailLoginScreen.kt
@@ -135,7 +135,12 @@ fun EmailLoginScreen(
                 isPassword = true
             )
 
-            uiState.errorMessage?.let { msg ->
+            val displayedError = when {
+                uiState.showInvalidCredentialsError -> stringResource(R.string.email_auth_login_invalid_credentials)
+                uiState.errorMessage != null -> uiState.errorMessage
+                else -> null
+            }
+            displayedError?.let { msg ->
                 Spacer(Modifier.height(MongleSpacing.sm))
                 Text(
                     text = msg,

--- a/app/src/main/java/com/mongle/android/ui/emailauth/EmailLoginViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/emailauth/EmailLoginViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
 
 private val EMAIL_REGEX = Regex("""^[^\s@]+@[^\s@]+\.[^\s@]+$""")
@@ -26,7 +27,9 @@ data class EmailLoginUiState(
     @StringRes val passwordErrorRes: Int? = null,
     val isSubmitting: Boolean = false,
     /** 서버 에러(이미 i18n 처리됨) 또는 null */
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    /** 401 응답 — 이메일/비밀번호 불일치 안내를 i18n 리소스로 노출 */
+    val showInvalidCredentialsError: Boolean = false
 ) {
     val isEmailValid: Boolean get() = EMAIL_REGEX.matches(email.trim())
     val isPasswordNonEmpty: Boolean get() = password.isNotEmpty()
@@ -50,11 +53,11 @@ class EmailLoginViewModel @Inject constructor(
     val events: SharedFlow<EmailLoginEvent> = _events.asSharedFlow()
 
     fun onEmailChanged(value: String) {
-        _uiState.update { it.copy(email = value, emailErrorRes = null, errorMessage = null) }
+        _uiState.update { it.copy(email = value, emailErrorRes = null, errorMessage = null, showInvalidCredentialsError = false) }
     }
 
     fun onPasswordChanged(value: String) {
-        _uiState.update { it.copy(password = value, passwordErrorRes = null, errorMessage = null) }
+        _uiState.update { it.copy(password = value, passwordErrorRes = null, errorMessage = null, showInvalidCredentialsError = false) }
     }
 
     fun submit() {
@@ -77,12 +80,22 @@ class EmailLoginViewModel @Inject constructor(
                 _uiState.update { it.copy(isSubmitting = false) }
                 _events.emit(EmailLoginEvent.Completed(result))
             } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(
-                        isSubmitting = false,
-                        // 서버가 i18n 처리한 메시지 우선; 없으면 화면에서 fallback 리소스 사용
-                        errorMessage = e.message
-                    )
+                val isUnauthorized = e is HttpException && e.code() == 401
+                _uiState.update { state ->
+                    if (isUnauthorized) {
+                        state.copy(
+                            isSubmitting = false,
+                            errorMessage = null,
+                            showInvalidCredentialsError = true
+                        )
+                    } else {
+                        state.copy(
+                            isSubmitting = false,
+                            // 서버가 i18n 처리한 메시지 우선; 없으면 화면에서 fallback 리소스 사용
+                            errorMessage = e.message,
+                            showInvalidCredentialsError = false
+                        )
+                    }
                 }
             }
         }
@@ -93,6 +106,6 @@ class EmailLoginViewModel @Inject constructor(
     }
 
     fun dismissError() {
-        _uiState.update { it.copy(errorMessage = null) }
+        _uiState.update { it.copy(errorMessage = null, showInvalidCredentialsError = false) }
     }
 }

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -18,6 +18,7 @@ import com.mongle.android.domain.repository.TreeRepository
 import com.mongle.android.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -93,6 +94,10 @@ class RootViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(RootUiState())
     val uiState: StateFlow<RootUiState> = _uiState.asStateFlow()
+
+    // 빠른 그룹 전환 시 이전 selectFamily/loadHomeData 흐름이 늦게 끝나
+    // 서버 활성 그룹과 클라이언트 활성 그룹이 어긋나는 race 를 차단한다.
+    private var groupSelectionJob: Job? = null
 
     init {
         checkAuthStatus()
@@ -221,7 +226,8 @@ class RootViewModel @Inject constructor(
     }
 
     fun onGroupSelected(familyId: java.util.UUID) {
-        viewModelScope.launch {
+        groupSelectionJob?.cancel()
+        groupSelectionJob = viewModelScope.launch {
             _uiState.update { it.copy(appState = AppState.Loading) }
             runCatching { mongleRepository.selectFamily(familyId) }
             loadHomeData()
@@ -343,12 +349,25 @@ class RootViewModel @Inject constructor(
     }
 
     fun logout() {
+        groupSelectionJob?.cancel()
         viewModelScope.launch {
             runCatching { authRepository.logout() }
+            clearUserScopedPrefs()
             _uiState.update {
                 RootUiState(appState = AppState.Unauthenticated)
             }
         }
+    }
+
+    /**
+     * 다음 계정 로그인 시 이전 사용자의 그룹별 마커/푸시 토큰이 혼입되지 않도록
+     * user-scoped SharedPreferences 를 일괄 정리한다.
+     * mongle_auth 는 authRepository.logout() 에서 정리되고,
+     * mongle_app_prefs (has_seen_onboarding, install sentinel) 는 보존한다.
+     */
+    private fun clearUserScopedPrefs() {
+        context.getSharedPreferences("mongle_heart", Context.MODE_PRIVATE).edit().clear().apply()
+        context.getSharedPreferences("fcm", Context.MODE_PRIVATE).edit().clear().apply()
     }
 
     fun onAnswerSubmitted(answer: Answer? = null, isNewAnswer: Boolean = true) {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -55,6 +55,7 @@
     <string name="email_auth_login_subtitle">登録したメールアドレスとパスワードを入力してください。</string>
     <string name="email_auth_login_submit">ログイン</string>
     <string name="email_auth_login_password_required">パスワードを入力してください。</string>
+    <string name="email_auth_login_invalid_credentials">メールアドレスまたはパスワードが正しくありません。\nご確認ください。</string>
 
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">モングルへ\nようこそ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -55,6 +55,7 @@
     <string name="email_auth_login_subtitle">가입하신 이메일과 비밀번호를 입력해주세요.</string>
     <string name="email_auth_login_submit">로그인</string>
     <string name="email_auth_login_password_required">비밀번호를 입력해주세요.</string>
+    <string name="email_auth_login_invalid_credentials">이메일 또는 비밀번호가 올바르지 않아요.\n다시 확인해주세요.</string>
 
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">몽글에 오신 걸\n환영해요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="email_auth_login_subtitle">Enter the email and password you signed up with.</string>
     <string name="email_auth_login_submit">Log in</string>
     <string name="email_auth_login_password_required">Please enter your password.</string>
+    <string name="email_auth_login_invalid_credentials">The email or password is incorrect.\nPlease check and try again.</string>
 
     <!-- Onboarding -->
     <string name="onboarding_welcome_title">Welcome to\nMongle</string>


### PR DESCRIPTION
## Jira
- [MG-82](https://ycompany.atlassian.net/browse/MG-82)

## Related
- iOS 패리티: MG-47/48/53/58/70

## Summary
- TokenAuthenticator hadRefreshTokenBefore 가드로 첫 설치 sessionExpired 차단
- MongleApplication install sentinel 도입
- groupSelectionJob 으로 그룹 전환 race 차단
- logout 시 user-scoped prefs (mongle_heart, fcm) 일괄 정리
- 이메일 로그인 401 → 친화 메시지 (i18n ko/en/ja)

## Test plan
- [ ] 신규 설치 첫 진입 sessionExpired 미노출
- [ ] 앱 재설치 후 자동 로그인 안 됨
- [ ] 그룹 빠른 연속 전환 일관 표시
- [ ] 잘못된 비번 → 친화 메시지 (3개 언어)
- [ ] 로그아웃 → 다른 계정 로그인 → 이전 마커 잔존 없음

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)