### PR TITLE
fix(notification): 배지·푸시·백그라운드 안정화 — type fallback·foreground guard·unreadCount 캐시 (MG-83)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.process)
 
     // Hilt
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
+++ b/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.mongle.android.MainActivity
@@ -16,8 +18,14 @@ class MongleFcmService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        getSharedPreferences("fcm", Context.MODE_PRIVATE)
-            .edit().putString("token", token).apply()
+        // 토큰 저장 실패가 silent 하게 묻히지 않도록 try-catch + 로그.
+        // 저장 실패 시 RootViewModel.loadHomeData 의 서버 등록도 건너뛰게 됨.
+        try {
+            getSharedPreferences("fcm", Context.MODE_PRIVATE)
+                .edit().putString("token", token).apply()
+        } catch (e: Exception) {
+            android.util.Log.e("MongleFcmService", "FCM 토큰 저장 실패", e)
+        }
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
@@ -47,12 +55,19 @@ class MongleFcmService : FirebaseMessagingService() {
             this, 0, intent, PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
         )
 
+        // 앱이 foreground 일 때 heads-up 배너로 흐름을 끊지 않도록 priority 를 낮춘다.
+        // 알림은 트레이/리스트로는 정상 노출되지만 헤드업 팝업은 표시되지 않는다.
+        val isForeground = ProcessLifecycleOwner.get().lifecycle.currentState
+            .isAtLeast(Lifecycle.State.STARTED)
+        val priority = if (isForeground) NotificationCompat.PRIORITY_LOW
+                       else NotificationCompat.PRIORITY_HIGH
+
         val notification = NotificationCompat.Builder(this, channelId)
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(title)
             .setContentText(body)
             .setAutoCancel(true)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setPriority(priority)
             .setContentIntent(pending)
             .build()
 

--- a/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
+++ b/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
@@ -109,6 +109,16 @@ fun MongleNavHost(
                     uiState.todayQuestion?.let { showQuestionDetail = it }
                 }
             }
+            "ALL_ANSWERED", "ANSWERER_NUDGE", "REMINDER", "BADGE_EARNED" -> {
+                // 추가 푸시 타입 — 안전하게 오늘 질문 진입(미답변일 때만)
+                if (!uiState.hasAnsweredToday) {
+                    uiState.todayQuestion?.let { showQuestionDetail = it }
+                }
+            }
+            else -> {
+                // 서버에서 신규 type 이 추가돼도 silent fail 하지 않고 홈 노출만 보장.
+                // 의도치 않은 화면 진입을 막기 위해 별도 동작은 하지 않는다.
+            }
         }
         rootViewModel.clearPendingNotification()
     }

--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationViewModel.kt
@@ -1,10 +1,13 @@
 package com.mongle.android.ui.notification
 
+import android.content.Context
+import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.data.remote.AppNotification
 import com.mongle.android.data.remote.ApiNotificationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,15 +20,35 @@ import javax.inject.Inject
 data class NotificationUiState(
     val notifications: List<AppNotification> = emptyList(),
     val isLoading: Boolean = false,
-    val errorMessage: String? = null
-) {
-    val unreadCount: Int get() = notifications.count { !it.isRead }
-}
+    val errorMessage: String? = null,
+    /**
+     * 미읽음 수. computed property 대신 stored property 로 두고
+     * notifications mutation 시점에만 갱신해 매 composable 재실행마다
+     * O(n) count 가 반복되는 비용을 제거한다.
+     */
+    val unreadCount: Int = 0
+)
 
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
-    private val notificationRepository: ApiNotificationRepository
+    private val notificationRepository: ApiNotificationRepository,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
+
+    /** 미읽음 수를 notifications 기준으로 재계산해 stored 값으로 반영한다. */
+    private fun refreshDerived(state: NotificationUiState): NotificationUiState =
+        state.copy(unreadCount = state.notifications.count { !it.isRead })
+
+    /**
+     * 인앱에서 알림을 모두 읽음/삭제 처리한 시점에 OS 알림 트레이의 푸시도 정리한다.
+     * 시스템 배지(채널 dot/숫자)는 OS 가 활성 알림 기준으로 자동 갱신하므로
+     * cancel 만으로 OS 배지 ↔ 인앱 미읽음 카운트 분리가 해소된다.
+     */
+    private fun cancelOsNotifications() {
+        runCatching {
+            NotificationManagerCompat.from(context).cancelAll()
+        }
+    }
 
     private val _uiState = MutableStateFlow(NotificationUiState())
     val uiState: StateFlow<NotificationUiState> = _uiState.asStateFlow()
@@ -53,7 +76,7 @@ class NotificationViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
             try {
                 val items = notificationRepository.getNotifications(familyId = familyId)
-                _uiState.update { it.copy(isLoading = false, notifications = items) }
+                _uiState.update { refreshDerived(it.copy(isLoading = false, notifications = items)) }
             } catch (e: Exception) {
                 _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
             }
@@ -63,10 +86,12 @@ class NotificationViewModel @Inject constructor(
     fun onMarkAsRead(notificationId: String) {
         // 낙관적 업데이트
         _uiState.update { state ->
-            state.copy(
-                notifications = state.notifications.map { n ->
-                    if (n.id == notificationId) n.copy(isRead = true) else n
-                }
+            refreshDerived(
+                state.copy(
+                    notifications = state.notifications.map { n ->
+                        if (n.id == notificationId) n.copy(isRead = true) else n
+                    }
+                )
             )
         }
         viewModelScope.launch {
@@ -81,8 +106,9 @@ class NotificationViewModel @Inject constructor(
             val updated = state.notifications.map { n ->
                 if (familyId == null || n.familyId == familyId) n.copy(isRead = true) else n
             }
-            state.copy(notifications = updated)
+            refreshDerived(state.copy(notifications = updated))
         }
+        cancelOsNotifications()
         viewModelScope.launch {
             withContext(NonCancellable) {
                 runCatching { notificationRepository.markAllAsRead(familyId) }
@@ -92,7 +118,9 @@ class NotificationViewModel @Inject constructor(
 
     fun onDeleteNotification(notificationId: String) {
         _uiState.update { state ->
-            state.copy(notifications = state.notifications.filter { it.id != notificationId })
+            refreshDerived(
+                state.copy(notifications = state.notifications.filter { it.id != notificationId })
+            )
         }
         // 화면을 즉시 벗어나도 서버 삭제가 완료되도록 NonCancellable 컨텍스트에서 실행한다.
         viewModelScope.launch {
@@ -119,7 +147,8 @@ class NotificationViewModel @Inject constructor(
         }
         if (toDelete.isEmpty()) return
         val remaining = current - toDelete.toSet()
-        _uiState.update { it.copy(notifications = remaining) }
+        _uiState.update { refreshDerived(it.copy(notifications = remaining)) }
+        cancelOsNotifications()
         // 서버 일괄 삭제 API 사용 — 이전에는 개별 삭제를 반복 호출했지만
         // 서버에 DELETE /notifications?group_id= 가 추가되어 1회 호출로 처리한다.
         // NonCancellable 로 화면 전환 시에도 요청 완료 보장.

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -311,7 +311,16 @@ class RootViewModel @Inject constructor(
         }
         // 로그인 직후엔 항상 그룹선택화면으로 이동 (기존 그룹 있어도 선택하게)
         viewModelScope.launch {
-            _uiState.update { it.copy(currentUser = user, appState = AppState.Loading) }
+            // Unauthenticated 상태에서 도착한 푸시 tap / 딥링크로 설정된 stale pending 신호를
+            // 새 사용자 화면이 자동 소비하지 않도록 명시 정리한다.
+            _uiState.update {
+                it.copy(
+                    currentUser = user,
+                    appState = AppState.Loading,
+                    pendingNotificationType = null,
+                    pendingInviteCode = null
+                )
+            }
             val allFamilies = runCatching { mongleRepository.getMyFamilies() }.getOrElse { emptyList() }
             _uiState.update { it.copy(appState = AppState.GroupSelection, allFamilies = allFamilies) }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ androidx-navigation-compose = { group = "androidx.navigation", name = "navigatio
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycle" }
 
 # Hilt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }


### PR DESCRIPTION
## Jira
- [MG-83](https://ycompany.atlassian.net/browse/MG-83)

## Related
- iOS 패리티: MG-39/55/61
- 의존: 없음 (MG-82 와 독립)

## Summary
- 푸시 type when 에 4개 type 추가 + else 안전 fallback
- foreground 시 NotificationCompat priority LOW (heads-up 차단)
- unreadCount stored + mark-all/delete-all 시 cancelAll() OS 동기화
- onLoggedIn pending 신호 명시 정리
- lifecycle-process 의존성 추가

## Test plan
- [ ] 새 푸시 → OS 트레이 + 인앱 unreadCount 동기
- [ ] mark-all/delete-all → OS 트레이 정리
- [ ] 앱 사용 중 푸시 heads-up 미노출
- [ ] 미지 type 푸시 시 크래시 없음
- [ ] 비로그인 푸시 → 다른 계정 로그인 시 stale 자동 진입 없음

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)