### PR TITLE
fix(hearts): 데일리 하트 트리거 서버 플래그 정합 + 답변 보상 +1 동기화 (MG-84)

### DIFF
--- a/app/src/main/java/com/mongle/android/data/remote/ApiAuthRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ApiAuthRepository.kt
@@ -58,7 +58,8 @@ class ApiAuthRepository @Inject constructor(
         role = FamilyRole.entries.firstOrNull { it.name == role } ?: FamilyRole.OTHER,
         hearts = hearts,
         moodId = moodId,
-        createdAt = Date()
+        createdAt = Date(),
+        heartGrantedToday = heartGrantedToday ?: false
     )
 
     private suspend fun <T> safeCall(block: suspend () -> T): T {
@@ -192,13 +193,15 @@ class ApiAuthRepository @Inject constructor(
         clearSession()
     }
 
-    override suspend fun getCurrentUser(): User? {
+    override suspend fun getCurrentUser(grantDailyHeart: Boolean): User? {
         // 저장된 토큰이 없으면 미로그인 상태
         val token = prefs.getString(KEY_TOKEN, null) ?: return null
 
         return try {
-            // 서버에서 최신 사용자 정보를 가져와 토큰 유효성 검증
-            val apiUser = api.getMe()
+            // 서버에서 최신 사용자 정보를 가져와 토큰 유효성 검증.
+            // grantDailyHeart=true 호출은 RootViewModel.loadHomeData 에서만 사용하여
+            // 데일리 하트 지급/heartGrantedToday 플래그를 set-only 트리거로 받는다.
+            val apiUser = api.getMe(grantDailyHeart = grantDailyHeart)
             saveSession(apiUser, token, prefs.getString(KEY_REFRESH_TOKEN, null))
             apiUser.toDomain()
         } catch (e: HttpException) {

--- a/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
@@ -41,7 +41,13 @@ data class ApiUserResponse(
     val familyId: String?,
     val hearts: Int = 0,
     val moodId: String? = null,
-    val createdAt: String
+    val createdAt: String,
+    /**
+     * 오늘 데일리 하트가 지급되었는지 여부.
+     * users/me?grantDailyHeart=true 호출 시에만 서버가 set 하며, 이미 받은 날에는 false.
+     * 미지원 서버 호환을 위해 nullable.
+     */
+    val heartGrantedToday: Boolean? = null
 )
 
 @JsonClass(generateAdapter = true)
@@ -380,7 +386,7 @@ interface MongleApiService {
 
     // Users
     @GET("users/me")
-    suspend fun getMe(): ApiUserResponse
+    suspend fun getMe(@retrofit2.http.Query("grantDailyHeart") grantDailyHeart: Boolean = false): ApiUserResponse
 
     @PUT("users/me")
     suspend fun updateMe(@Body body: UpdateUserRequest): ApiUserResponse

--- a/app/src/main/java/com/mongle/android/domain/model/User.kt
+++ b/app/src/main/java/com/mongle/android/domain/model/User.kt
@@ -12,7 +12,9 @@ data class User(
     val hearts: Int = 0,
     val moodId: String? = null,
     val createdAt: Date,
-    val lastNameChangedAt: Long? = null
+    val lastNameChangedAt: Long? = null,
+    /** users/me?grantDailyHeart=true 응답에서만 true 가 올 수 있음 */
+    val heartGrantedToday: Boolean = false
 )
 
 enum class FamilyRole(val displayName: String) {

--- a/app/src/main/java/com/mongle/android/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/mongle/android/domain/repository/AuthRepository.kt
@@ -13,7 +13,14 @@ interface AuthRepository {
     suspend fun socialLogin(credential: SocialLoginCredential): SocialLoginResult
     suspend fun logout()
     suspend fun deleteAccount()
-    suspend fun getCurrentUser(): User?
+
+    /**
+     * 현재 사용자 정보 조회.
+     * @param grantDailyHeart true 면 서버가 데일리 하트를 지급(또는 이미 받음) 후
+     *                        heartGrantedToday 플래그를 응답에 포함. RootViewModel.loadHomeData
+     *                        같은 단일 진입점에서만 true 로 호출해야 한다.
+     */
+    suspend fun getCurrentUser(grantDailyHeart: Boolean = false): User?
 
     /**
      * 약관/개인정보 동의 저장.

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -165,21 +165,10 @@ class RootViewModel @Inject constructor(
                     // No active family → go to GroupSelection
                     _uiState.update { it.copy(appState = AppState.GroupSelection, allFamilies = allFamilies) }
                 } else {
-                    // 하루 첫 접속 하트 팝업 체크 (그룹별, iOS와 동일 로직)
-                    // 서버의 auth middleware recordAccess가 자동으로 하트를 증가시킴
-                    val heartPopupKey = "mongle.lastHeartPopupDate.${family.id}"
-                    val heartPrefs = context.getSharedPreferences("mongle_heart", Context.MODE_PRIVATE)
-                    val todayStart = java.util.Calendar.getInstance().apply {
-                        set(java.util.Calendar.HOUR_OF_DAY, 0)
-                        set(java.util.Calendar.MINUTE, 0)
-                        set(java.util.Calendar.SECOND, 0)
-                        set(java.util.Calendar.MILLISECOND, 0)
-                    }.timeInMillis
-                    val lastPopupTime = heartPrefs.getLong(heartPopupKey, 0L)
-                    val isFirstAccessToday = lastPopupTime < todayStart
-                    if (isFirstAccessToday) {
-                        heartPrefs.edit().putLong(heartPopupKey, todayStart).apply()
-                    }
+                    // 데일리 하트 지급 트리거 — 서버가 set-only 로 heartGrantedToday=true 를 응답.
+                    // 클라 SharedPreferences 자체 카운터 방식은 다중 단말/그룹 전환 시 거짓 팝업이 발생해 폐기.
+                    val refreshedUser = runCatching { authRepository.getCurrentUser(grantDailyHeart = true) }.getOrNull()
+                    val heartGrantedToday = refreshedUser?.heartGrantedToday ?: false
 
                     // FCM 토큰 서버 등록
                     runCatching {
@@ -193,7 +182,9 @@ class RootViewModel @Inject constructor(
 
                     _uiState.update {
                         val serverMe = members.firstOrNull { m -> m.id == it.currentUser?.id }
-                        val syncedUser = serverMe ?: it.currentUser
+                        // refreshedUser 우선 — 서버 grantDailyHeart 응답이 가장 최신.
+                        // members 의 me 는 hearts 등 일부 필드만 동기화되며 heartGrantedToday 는 미포함.
+                        val syncedUser = refreshedUser ?: serverMe ?: it.currentUser
                         it.copy(
                             appState = AppState.Authenticated,
                             todayQuestion = question,
@@ -204,7 +195,8 @@ class RootViewModel @Inject constructor(
                             allFamilies = allFamilies,
                             hasAnsweredToday = question?.hasMyAnswer ?: false,
                             hasSkippedToday = question?.hasMySkipped ?: false,
-                            dailyHeartGranted = if (isFirstAccessToday) 1 else 0,
+                            // set-only — heartGrantedToday=false 응답일 땐 기존 값 유지(이미 본 팝업 재트리거 방지)
+                            dailyHeartGranted = if (heartGrantedToday) 1 else it.dailyHeartGranted,
                             currentUser = syncedUser
                         )
                     }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -80,7 +80,7 @@
     <string name="home_heart_replace">質問をもらい直す</string>
     <string name="home_heart_write">自分だけの質問作成</string>
     <string name="home_heart_nudge">催促する</string>
-    <string name="home_heart_earn_rate">毎朝 +1 · 回答完了 +3</string>
+    <string name="home_heart_earn_rate">毎朝 +1 · 回答完了 +1</string>
     <string name="home_group_manage">グループ管理</string>
     <string name="home_answer_first_title">まず回答を完了してください</string>
     <string name="home_answer_first_view_desc">%sの回答を見るには\nまず今日の質問に答えてください</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -80,7 +80,7 @@
     <string name="home_heart_replace">질문 다시받기</string>
     <string name="home_heart_write">나만의 질문 작성</string>
     <string name="home_heart_nudge">재촉하기</string>
-    <string name="home_heart_earn_rate">매일 오전 +1 · 답변 완료 +3</string>
+    <string name="home_heart_earn_rate">매일 오전 +1 · 답변 완료 +1</string>
     <string name="home_group_manage">그룹 관리</string>
     <string name="home_answer_first_title">먼저 답변을 완료해 주세요</string>
     <string name="home_answer_first_view_desc">%s의 답변을 보려면\n먼저 오늘의 질문에 답변해야 해요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,7 +80,7 @@
     <string name="home_heart_replace">Replace question</string>
     <string name="home_heart_write">Write my question</string>
     <string name="home_heart_nudge">Nudge</string>
-    <string name="home_heart_earn_rate">Daily +1 · Answer +3</string>
+    <string name="home_heart_earn_rate">Daily +1 · Answer +1</string>
     <string name="home_group_manage">Manage Groups</string>
     <string name="home_answer_first_title">Please answer first</string>
     <string name="home_answer_first_view_desc">To see %s\'s answer,\nyou need to answer today\'s question first</string>


### PR DESCRIPTION
## Jira
- [MG-84](https://ycompany.atlassian.net/browse/MG-84)

## Related
- iOS 패리티: MG-74/77
- 의존: 없음

## Summary
- ApiUserResponse.heartGrantedToday + getMe(grantDailyHeart) 시그니처
- AuthRepository/User 도메인 시그니처 확장
- RootViewModel.loadHomeData SharedPreferences 카운터 폐기 → 서버 set-only 트리거
- strings.xml 3개 언어 "+3" → "+1"

## Test plan
- [ ] 홈 하트 callout 3개 언어 모두 +1 표기
- [ ] 다중 단말 데일리 팝업 1회만 노출
- [ ] 그룹 전환에 의한 거짓 팝업 없음

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)