### PR TITLE
fix(error): 에러 안내 일괄 — raw 제거·silent fallback 안내·mutation 노출 (MG-85)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/consent/ConsentViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/consent/ConsentViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.consent
 
 import androidx.lifecycle.ViewModel
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.domain.model.LegalDocType
 import com.mongle.android.domain.model.LegalVersions
@@ -100,7 +101,7 @@ class ConsentViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isSubmitting = false,
-                        errorMessage = e.message ?: "동의 저장에 실패했습니다."
+                        errorMessage = AppError.from(e).toastMessage
                     )
                 }
             }

--- a/app/src/main/java/com/mongle/android/ui/emailauth/EmailSignupViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/emailauth/EmailSignupViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.emailauth
 
 import androidx.annotation.StringRes
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ycompany.Monggle.R
@@ -135,7 +136,7 @@ class EmailSignupViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isSendingCode = false,
-                        errorMessage = e.message
+                        errorMessage = AppError.from(e).toastMessage
                     )
                 }
             }
@@ -155,7 +156,7 @@ class EmailSignupViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isSendingCode = false,
-                        errorMessage = e.message
+                        errorMessage = AppError.from(e).toastMessage
                     )
                 }
             }
@@ -193,7 +194,7 @@ class EmailSignupViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isVerifying = false,
-                        codeError = e.message
+                        codeError = AppError.from(e).toastMessage
                     )
                 }
             }

--- a/app/src/main/java/com/mongle/android/ui/groupselect/GroupSelectViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/groupselect/GroupSelectViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.groupselect
 
 import androidx.lifecycle.ViewModel
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.domain.model.FamilyRole
 import com.mongle.android.domain.model.MongleGroup
@@ -43,9 +44,18 @@ class GroupSelectViewModel @Inject constructor(
 
     fun loadGroups() {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            val groups = runCatching { familyRepository.getMyFamilies() }.getOrElse { emptyList() }
-            _uiState.update { it.copy(groups = groups, isLoading = false) }
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            runCatching { familyRepository.getMyFamilies() }
+                .onSuccess { groups ->
+                    _uiState.update { it.copy(groups = groups, isLoading = false) }
+                }
+                .onFailure { e ->
+                    // 이전엔 emptyList() 로 silent fallback 하여 사용자가 "그룹이 없음"으로 오해.
+                    // 빈 목록 + errorMessage 로 명확히 안내한다.
+                    _uiState.update {
+                        it.copy(groups = emptyList(), isLoading = false, errorMessage = AppError.from(e).toastMessage)
+                    }
+                }
         }
     }
 
@@ -91,11 +101,12 @@ class GroupSelectViewModel @Inject constructor(
                     it.copy(inviteCode = group.inviteCode, step = GroupSelectStep.NOTIFICATION_PERMISSION, isLoading = false)
                 }
             }.onFailure { e ->
-                val msg = e.message ?: "그룹 생성에 실패했어요"
-                if (msg.contains("최대") || msg.contains("3개")) {
+                val appError = AppError.from(e)
+                val rawMsg = (appError as? AppError.Domain)?.message ?: e.message ?: ""
+                if (rawMsg.contains("최대") || rawMsg.contains("3개")) {
                     _uiState.update { it.copy(showMaxGroupsAlert = true, isLoading = false) }
                 } else {
-                    _uiState.update { it.copy(errorMessage = msg, isLoading = false) }
+                    _uiState.update { it.copy(errorMessage = appError.toastMessage, isLoading = false) }
                 }
             }
         }
@@ -126,13 +137,14 @@ class GroupSelectViewModel @Inject constructor(
                 _uiState.update { it.copy(isLoading = false) }
                 onJoined()
             }.onFailure { e ->
-                val msg = e.message ?: "참여에 실패했어요"
-                if (msg.contains("최대") || msg.contains("3개")) {
+                val appError = AppError.from(e)
+                val rawMsg = (appError as? AppError.Domain)?.message ?: e.message ?: ""
+                if (rawMsg.contains("최대") || rawMsg.contains("3개")) {
                     _uiState.update { it.copy(showMaxGroupsAlert = true, isLoading = false) }
-                } else if (msg.contains("유효하지") || msg.contains("찾을 수 없")) {
+                } else if (rawMsg.contains("유효하지") || rawMsg.contains("찾을 수 없")) {
                     _uiState.update { it.copy(errorMessage = "유효하지 않은 초대 코드예요. 다시 확인해 주세요.", isLoading = false) }
                 } else {
-                    _uiState.update { it.copy(errorMessage = msg, isLoading = false) }
+                    _uiState.update { it.copy(errorMessage = appError.toastMessage, isLoading = false) }
                 }
             }
         }

--- a/app/src/main/java/com/mongle/android/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/history/HistoryViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.history
 
 import androidx.lifecycle.ViewModel
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.domain.model.HistoryAnswerSummary
 import com.mongle.android.domain.model.HistorySkippedSummary
@@ -150,7 +151,7 @@ class HistoryViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(isLoading = false, errorMessage = e.message)
+                    it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage)
                 }
             }
         }

--- a/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.home
 
 import androidx.lifecycle.ViewModel
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.domain.model.Answer
 import com.mongle.android.domain.model.MongleGroup
@@ -212,6 +213,8 @@ class HomeViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 android.util.Log.e("HomeVM", "loadFamilyAnswers failed", e)
+                // 사용자가 "왜 답변이 안 보이지?" 오해하지 않도록 명시 안내.
+                _uiState.update { it.copy(errorMessage = AppError.from(e).toastMessage) }
             }
         }
     }
@@ -261,7 +264,7 @@ class HomeViewModel @Inject constructor(
                 question?.dailyQuestionId?.let { loadFamilyAnswers(it) }
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(isRefreshing = false, errorMessage = e.message)
+                    it.copy(isRefreshing = false, errorMessage = AppError.from(e).toastMessage)
                 }
             }
         }

--- a/app/src/main/java/com/mongle/android/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/login/LoginViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.login
 
 import android.util.Log
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.domain.model.LegalDocType
@@ -72,7 +73,7 @@ class LoginViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        errorMessage = e.message ?: "${credential.providerType.value} 로그인에 실패했습니다."
+                        errorMessage = AppError.from(e).toastMessage
                     )
                 }
             }

--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.notification
 
 import androidx.lifecycle.ViewModel
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.data.remote.AppNotification
 import com.mongle.android.data.remote.ApiNotificationRepository
@@ -55,7 +56,7 @@ class NotificationViewModel @Inject constructor(
                 val items = notificationRepository.getNotifications(familyId = familyId)
                 _uiState.update { it.copy(isLoading = false, notifications = items) }
             } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
+                _uiState.update { it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage) }
             }
         }
     }
@@ -71,6 +72,10 @@ class NotificationViewModel @Inject constructor(
         }
         viewModelScope.launch {
             runCatching { notificationRepository.markAsRead(notificationId) }
+                .onFailure { e ->
+                    // optimistic update 는 유지(rollback 안 함). 실패 시 사용자 안내만 추가.
+                    _uiState.update { it.copy(errorMessage = AppError.from(e).toastMessage) }
+                }
         }
     }
 
@@ -86,6 +91,9 @@ class NotificationViewModel @Inject constructor(
         viewModelScope.launch {
             withContext(NonCancellable) {
                 runCatching { notificationRepository.markAllAsRead(familyId) }
+                    .onFailure { e ->
+                        _uiState.update { it.copy(errorMessage = AppError.from(e).toastMessage) }
+                    }
             }
         }
     }
@@ -98,6 +106,9 @@ class NotificationViewModel @Inject constructor(
         viewModelScope.launch {
             withContext(NonCancellable) {
                 runCatching { notificationRepository.deleteNotification(notificationId) }
+                    .onFailure { e ->
+                        _uiState.update { it.copy(errorMessage = AppError.from(e).toastMessage) }
+                    }
             }
         }
     }
@@ -126,6 +137,9 @@ class NotificationViewModel @Inject constructor(
         viewModelScope.launch {
             withContext(NonCancellable) {
                 runCatching { notificationRepository.deleteAll(familyId) }
+                    .onFailure { e ->
+                        _uiState.update { it.copy(errorMessage = AppError.from(e).toastMessage) }
+                    }
             }
         }
     }

--- a/app/src/main/java/com/mongle/android/ui/nudge/PeerNudgeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/nudge/PeerNudgeViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.nudge
 
 import androidx.lifecycle.ViewModel
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.data.remote.ApiNudgeRepository
 import com.mongle.android.data.remote.ApiUserRepository
@@ -63,7 +64,7 @@ class PeerNudgeViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
+                _uiState.update { it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage) }
             }
         }
     }
@@ -87,7 +88,7 @@ class PeerNudgeViewModel @Inject constructor(
                             )
                         }
                     } catch (e: Exception) {
-                        _uiState.update { it.copy(isWatchingAd = false, errorMessage = e.message) }
+                        _uiState.update { it.copy(isWatchingAd = false, errorMessage = AppError.from(e).toastMessage) }
                     }
                 }
             },

--- a/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.question
 
 import androidx.lifecycle.ViewModel
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.data.remote.ApiUserRepository
 import com.mongle.android.domain.model.Answer
@@ -115,7 +116,7 @@ class QuestionDetailViewModel @Inject constructor(
                     )
                 }
             } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
+                _uiState.update { it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage) }
             }
         }
     }
@@ -182,7 +183,7 @@ class QuestionDetailViewModel @Inject constructor(
                         // 광고 시청 후 바로 수정 실행
                         doSubmitAnswer()
                     } catch (e: Exception) {
-                        _uiState.update { it.copy(isWatchingAd = false, errorMessage = e.message) }
+                        _uiState.update { it.copy(isWatchingAd = false, errorMessage = AppError.from(e).toastMessage) }
                     }
                 }
             },
@@ -226,7 +227,7 @@ class QuestionDetailViewModel @Inject constructor(
                 _events.emit(QuestionDetailEvent.AnswerSubmitted(savedAnswer, isNewAnswer))
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(isSubmitting = false, errorMessage = e.message ?: "답변 제출에 실패했습니다.")
+                    it.copy(isSubmitting = false, errorMessage = AppError.from(e).toastMessage)
                 }
             }
         }

--- a/app/src/main/java/com/mongle/android/ui/question/WriteQuestionViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/WriteQuestionViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.question
 
 import androidx.lifecycle.ViewModel
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
 import com.mongle.android.domain.model.Question
 import com.mongle.android.domain.repository.QuestionRepository
@@ -55,7 +56,7 @@ class WriteQuestionViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         isSubmitting = false,
-                        errorMessage = e.message ?: "질문 등록에 실패했습니다."
+                        errorMessage = AppError.from(e).toastMessage
                     )
                 }
             }

--- a/app/src/main/java/com/mongle/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/search/SearchViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.search
 
 import android.util.Log
+import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ycompany.Monggle.BuildConfig
@@ -98,7 +99,7 @@ class SearchViewModel @Inject constructor(
                     performSearch(_uiState.value.query)
                 }
             } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, errorMessage = e.message) }
+                _uiState.update { it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage) }
             }
         }
     }

--- a/app/src/main/java/com/mongle/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/settings/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.mongle.android.ui.settings
 
 import android.app.Activity
+import com.mongle.android.ui.common.AppError
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -170,7 +171,7 @@ class SettingsViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(isLoading = false, errorMessage = e.message ?: "프로필 업데이트에 실패했습니다.")
+                    it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage)
                 }
             }
         }
@@ -237,7 +238,7 @@ class SettingsViewModel @Inject constructor(
                 _events.emit(SettingsEvent.LeftGroup)
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(isLoading = false, errorMessage = e.message ?: "그룹 탈퇴에 실패했습니다.")
+                    it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage)
                 }
             }
         }
@@ -262,7 +263,7 @@ class SettingsViewModel @Inject constructor(
                 _events.emit(SettingsEvent.LeftGroup)
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(isLoading = false, errorMessage = e.message ?: "그룹 탈퇴에 실패했습니다.")
+                    it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage)
                 }
             }
         }
@@ -287,7 +288,7 @@ class SettingsViewModel @Inject constructor(
                 }
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(errorMessage = e.message ?: "멤버 내보내기에 실패했습니다.")
+                    it.copy(errorMessage = AppError.from(e).toastMessage)
                 }
             }
         }
@@ -343,7 +344,7 @@ class SettingsViewModel @Inject constructor(
                 _events.emit(SettingsEvent.AccountDeleted)
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(isLoading = false, errorMessage = e.message ?: "계정 삭제에 실패했습니다.")
+                    it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage)
                 }
             }
         }


### PR DESCRIPTION
## Jira
- [MG-85](https://ycompany.atlassian.net/browse/MG-85)

## Related
- iOS 패리티: MG-71/72/73
- 의존: 없음 (AppError.kt 이미 존재)

## Summary
- 12개 ViewModel raw e.message → AppError.from(e).toastMessage 통일
- HomeViewModel/GroupSelectViewModel silent fallback 제거
- NotificationViewModel 4 mutation onFailure 안내 추가

## Test plan
- [ ] 비행기 모드로 전 화면 에러 메시지 검증
- [ ] 알림 mutation 에러 → 안내 노출
- [ ] 그룹 로드 실패 → 빈 목록 + errorMessage

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)