### PR TITLE
fix(ux): UX·모달·게스트 안정화 — onResume hearts·게스트 게이트·closeTapped guard·토스트 4초 (MG-86)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/common/MongleToast.kt
+++ b/app/src/main/java/com/mongle/android/ui/common/MongleToast.kt
@@ -197,10 +197,10 @@ fun MongleToastOverlay(
     onDismiss: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
-    // 3초 후 자동 dismiss
+    // 4초 후 자동 dismiss (긴 메시지 가독성)
     LaunchedEffect(message) {
         if (message != null && onDismiss != null) {
-            delay(3000L)
+            delay(4000L)
             onDismiss()
         }
     }
@@ -243,10 +243,10 @@ fun MongleToastHost(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // 3초 후 자동 dismiss
+    // 4초 후 자동 dismiss (긴 메시지 가독성)
     LaunchedEffect(toastData) {
         if (toastData != null) {
-            delay(3000L)
+            delay(4000L)
             onDismiss()
         }
     }

--- a/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
@@ -201,6 +201,13 @@ fun HomeScreen(
                 }
                 is HomeEvent.ShowAnswerFirstToView -> showAnswerFirstDialog = event.memberName
                 is HomeEvent.ShowNudgeUnavailable -> showNudgeUnavailableDialog = event.memberName
+                HomeEvent.ShowGuestLoginRequired -> {
+                    // 게스트 모드 — 로그인 유도 토스트로 안내. iOS MG-50 패리티.
+                    toastData = MongleToastData(
+                        message = "로그인 후 이용할 수 있어요",
+                        type = MongleToastType.ERROR
+                    )
+                }
                 is HomeEvent.ShowError -> {
                     val msg = when {
                         event.message.contains("이미 답변") -> context.getString(R.string.error_already_answered_skip)
@@ -341,7 +348,12 @@ fun HomeScreen(
                 showGroupDropdown = showGroupDropdown,
                 onGroupDropdownToggle = { showGroupDropdown = !showGroupDropdown },
                 onTopBarMeasured = { topBarHeightPx = it },
-                onNotificationTap = onNavigateToNotifications,
+                onNotificationTap = {
+                    // 게스트 모드 가드 — true 일 때만 실제 진입.
+                    if (viewModel.requestNotificationsEntry()) {
+                        onNavigateToNotifications()
+                    }
+                },
                 onGroupManage = onNavigateToGroupSelect
             )
 

--- a/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
@@ -57,6 +57,8 @@ sealed class HomeEvent {
     data class ShowAnswerFirstToView(val memberName: String) : HomeEvent()
     data class ShowNudgeUnavailable(val memberName: String) : HomeEvent()
     data class ShowError(val message: String) : HomeEvent()
+    /** 게스트 모드(currentUser == null)에서 인증이 필요한 액션 진입 시 노출되는 안내 */
+    object ShowGuestLoginRequired : HomeEvent()
     object NavigateToWriteQuestion : HomeEvent()
 }
 
@@ -377,9 +379,27 @@ class HomeViewModel @Inject constructor(
     }
 
     fun onNudgeTapped(member: User) {
+        if (_uiState.value.currentUser == null) {
+            // 게스트 모드 — 로그인 유도 안내. iOS MG-50 패리티.
+            viewModelScope.launch { _events.emit(HomeEvent.ShowGuestLoginRequired) }
+            return
+        }
         viewModelScope.launch {
             _events.emit(HomeEvent.NavigateToNudge(member))
         }
+    }
+
+    /**
+     * 알림 화면 진입 전 게스트 가드. HomeScreen 의 onNotificationTap 콜백이
+     * 호출하여 currentUser == null 이면 로그인 유도 안내를 표시한다.
+     * @return true 면 호출자가 실제 네비게이션 진행, false 면 가드 발화.
+     */
+    fun requestNotificationsEntry(): Boolean {
+        if (_uiState.value.currentUser == null) {
+            viewModelScope.launch { _events.emit(HomeEvent.ShowGuestLoginRequired) }
+            return false
+        }
+        return true
     }
 
     fun skipQuestion() {

--- a/app/src/main/java/com/mongle/android/ui/question/QuestionDetailScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/QuestionDetailScreen.kt
@@ -110,8 +110,19 @@ fun QuestionDetailScreen(
     val focusManager = LocalFocusManager.current
     var toastData by remember { mutableStateOf<MongleToastData?>(null) }
 
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     LaunchedEffect(question, currentUser) {
         viewModel.initialize(question, currentUser, familyMembers, currentUserHearts)
+    }
+    // onResume 동등 — 화면 재진입 시 서버에서 hearts 재조회 (다중 단말 동기화)
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshHearts()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     LaunchedEffect(Unit) {
@@ -141,7 +152,13 @@ fun QuestionDetailScreen(
                     )
                 },
                 navigationIcon = {
-                    IconButton(onClick = onClose) {
+                    IconButton(
+                        onClick = {
+                            // 답변 제출 중에는 close 처리하지 않는다.
+                            // 부모의 path.removeLast() 와 race 가 발생할 수 있음 (iOS MG-56 패리티).
+                            if (!uiState.isSubmitting) onClose()
+                        }
+                    ) {
                         Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.common_back))
                     }
                 },

--- a/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
@@ -81,6 +81,20 @@ class QuestionDetailViewModel @Inject constructor(
             )
         }
         loadAnswers(question, currentUser)
+        // 부모에서 캡처한 hearts 는 stale 일 수 있음(다른 단말에서 답변/스킵/edit 으로 변경됨).
+        // 진입 시 서버에서 최신 값을 가져와 editCostPopup/adReward 분기가 올바른 잔량으로 동작하게 한다.
+        refreshHearts()
+    }
+
+    /**
+     * 화면 진입 또는 재진입(onResume) 시 서버에서 최신 hearts 를 받아 갱신.
+     * 다중 단말 동기화 필요 (iOS MG-49 패리티).
+     */
+    fun refreshHearts() {
+        viewModelScope.launch {
+            runCatching { userRepository.getMe() }
+                .onSuccess { me -> _uiState.update { it.copy(hearts = me.hearts) } }
+        }
     }
 
     private fun loadAnswers(question: Question, currentUser: User?) {


### PR DESCRIPTION
## Jira
- [MG-86](https://ycompany.atlassian.net/browse/MG-86)

## Related
- iOS 패리티: MG-49/50/56/57
- 의존: 없음

## Summary
- QuestionDetailVM refreshHearts + Lifecycle ON_RESUME
- HomeVM 게스트 가드 + ShowGuestLoginRequired 이벤트
- closeTapped !isSubmitting 가드
- 토스트 dismiss 3000L → 4000L

## Test plan
- [ ] 다중 단말 hearts 동기화
- [ ] 게스트 알림/nudge 진입 안내
- [ ] 답변 제출 중 back 무반응
- [ ] 토스트 4초

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)