### PR TITLE
perf: History/Search/QuestionDetail 성능 캐싱 — Calendar·grouping·matching 사전 계산 (MG-87)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/history/HistoryScreen.kt
@@ -182,25 +182,29 @@ fun HistoryScreen(
                         }
                     }
 
-                    // 달력 그리드
-                    val calendarDays = generateCalendarDays(uiState.currentMonth)
-                    val weeks = calendarDays.chunked(7)
+                    // 달력 그리드 — iOS MG-59 패리티: 사전 계산된 calendarDays 사용 (매 재실행 재계산 제거)
+                    val selectedDateMillis = remember(uiState.selectedDate) {
+                        Calendar.getInstance().apply {
+                            time = uiState.selectedDate
+                            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+                            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+                        }.timeInMillis
+                    }
+                    val weeks = uiState.calendarDays.chunked(7)
                     weeks.forEach { week ->
                         Row(modifier = Modifier.fillMaxWidth()) {
-                            week.forEach { date ->
+                            week.forEach { day ->
                                 CalendarDayCell(
-                                    date = date,
-                                    currentMonth = uiState.currentMonth,
-                                    selectedDate = uiState.selectedDate,
-                                    hasRecord = date?.let {
-                                        val cal = Calendar.getInstance().apply {
-                                            time = it
-                                            set(Calendar.HOUR_OF_DAY, 0)
-                                            set(Calendar.MINUTE, 0)
-                                            set(Calendar.SECOND, 0)
-                                            set(Calendar.MILLISECOND, 0)
-                                        }
-                                        uiState.historyItems[cal.timeInMillis] != null
+                                    day = day,
+                                    selectedDateMillis = selectedDateMillis,
+                                    hasRecord = day?.let {
+                                        uiState.historyItems[
+                                            Calendar.getInstance().apply {
+                                                time = it.date
+                                                set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+                                                set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+                                            }.timeInMillis
+                                        ] != null
                                     } ?: false,
                                     onDateSelected = { d -> d?.let { viewModel.onDateSelected(it) } },
                                     modifier = Modifier.weight(1f)
@@ -255,52 +259,40 @@ fun HistoryScreen(
     }
 }
 
-// ── 달력 날짜 셀 ──
+// ── 달력 날짜 셀 ── iOS MG-59 패리티: ViewModel 사전 계산 CalendarDayInfo 소비
 
 @Composable
 private fun CalendarDayCell(
-    date: Date?,
-    currentMonth: Date,
-    selectedDate: Date,
+    day: CalendarDayInfo?,
+    selectedDateMillis: Long,
     hasRecord: Boolean,
     onDateSelected: (Date?) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val isCurrentMonth = date?.let {
-        val dateCal = Calendar.getInstance().apply { time = it }
-        val monthCal = Calendar.getInstance().apply { time = currentMonth }
-        dateCal.get(Calendar.MONTH) == monthCal.get(Calendar.MONTH) &&
-            dateCal.get(Calendar.YEAR) == monthCal.get(Calendar.YEAR)
+    val isCurrentMonth = day?.isCurrentMonth ?: false
+    val isToday = day?.isToday ?: false
+    val isSelected = day?.let {
+        // selectedDateMillis 는 부모에서 정규화된 timestamp.
+        // day.date 는 normalize 된 자정 기준 (computeCalendarDays 가 정규화) 이라 직접 비교 가능.
+        Calendar.getInstance().apply {
+            time = it.date
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+        }.timeInMillis == selectedDateMillis
     } ?: false
-
-    val isSelected = date?.let {
-        val dateCal = Calendar.getInstance().apply { time = it }
-        val selCal = Calendar.getInstance().apply { time = selectedDate }
-        dateCal.get(Calendar.DAY_OF_YEAR) == selCal.get(Calendar.DAY_OF_YEAR) &&
-            dateCal.get(Calendar.YEAR) == selCal.get(Calendar.YEAR)
-    } ?: false
-
-    val isToday = date?.let {
-        val dateCal = Calendar.getInstance().apply { time = it }
-        val todayCal = Calendar.getInstance()
-        dateCal.get(Calendar.DAY_OF_YEAR) == todayCal.get(Calendar.DAY_OF_YEAR) &&
-            dateCal.get(Calendar.YEAR) == todayCal.get(Calendar.YEAR)
-    } ?: false
-
-    val dayOfWeek = date?.let { Calendar.getInstance().apply { time = it }.get(Calendar.DAY_OF_WEEK) }
 
     val numColor: Color = when {
         isToday -> Color.White
         !isCurrentMonth -> MongleTextHint.copy(alpha = 0.4f)
-        dayOfWeek == Calendar.SUNDAY -> MaterialTheme.colorScheme.error
-        dayOfWeek == Calendar.SATURDAY -> Color(0xFF1565C0)
+        day?.weekday == Calendar.SUNDAY -> MaterialTheme.colorScheme.error
+        day?.weekday == Calendar.SATURDAY -> Color(0xFF1565C0)
         else -> MongleTextPrimary
     }
 
     Column(
         modifier = modifier
             .height(54.dp)
-            .clickable(enabled = date != null && isCurrentMonth) { onDateSelected(date) },
+            .clickable(enabled = day != null && isCurrentMonth) { onDateSelected(day?.date) },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -318,9 +310,7 @@ private fun CalendarDayCell(
             contentAlignment = Alignment.Center
         ) {
             Text(
-                text = date?.let {
-                    Calendar.getInstance().apply { time = it }.get(Calendar.DAY_OF_MONTH).toString()
-                } ?: "",
+                text = day?.dayString ?: "",
                 style = MaterialTheme.typography.bodySmall.copy(
                     fontWeight = if (hasRecord) FontWeight.Medium else FontWeight.Normal
                 ),
@@ -564,24 +554,3 @@ private fun EmptyDateCard(selectedDate: Date, modifier: Modifier = Modifier) {
     }
 }
 
-private fun generateCalendarDays(month: Date): List<Date?> {
-    val cal = Calendar.getInstance().apply {
-        time = month
-        set(Calendar.DAY_OF_MONTH, 1)
-    }
-    val firstDayOfWeek = cal.get(Calendar.DAY_OF_WEEK) - 1 // 0=일
-    val daysInMonth = cal.getActualMaximum(Calendar.DAY_OF_MONTH)
-    val days = mutableListOf<Date?>()
-
-    repeat(firstDayOfWeek) { days.add(null) }
-
-    repeat(daysInMonth) { i ->
-        days.add(Calendar.getInstance().apply {
-            time = month
-            set(Calendar.DAY_OF_MONTH, i + 1)
-        }.time)
-    }
-
-    while (days.size < 42) days.add(null)
-    return days
-}

--- a/app/src/main/java/com/mongle/android/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/history/HistoryViewModel.kt
@@ -36,6 +36,19 @@ data class HistoryItem(
     val skippedMembers: List<HistorySkippedSummary> = emptyList()
 )
 
+/**
+ * 달력 한 셀에 필요한 사전 계산 정보. iOS MG-59 패리티.
+ * 매 composable 재실행마다 Calendar.getInstance() 4~5회 호출하던 비용을 없애기 위해
+ * monthly transition 시점(loadHistory/previousMonth/nextMonth)에 1회만 계산해 stored 한다.
+ */
+data class CalendarDayInfo(
+    val date: Date,
+    val dayString: String,
+    val weekday: Int,            // Calendar.DAY_OF_WEEK (1=일~7=토)
+    val isCurrentMonth: Boolean,
+    val isToday: Boolean
+)
+
 data class HistoryUiState(
     val selectedDate: Date = Date(),
     val currentMonth: Date = Date(),
@@ -43,14 +56,11 @@ data class HistoryUiState(
     val selectedItem: HistoryItem? = null,
     val moodCounts: Map<String, Int> = emptyMap(),
     val isLoading: Boolean = false,
-    val errorMessage: String? = null
-) {
-    val monthTitle: String
-        get() {
-            val cal = Calendar.getInstance().apply { time = currentMonth }
-            return "${cal.get(Calendar.YEAR)}년 ${cal.get(Calendar.MONTH) + 1}월"
-        }
-}
+    val errorMessage: String? = null,
+    /** 6주×7일 = 42 셀. null = 빈 칸. iOS MG-59 stored property 캐시. */
+    val calendarDays: List<CalendarDayInfo?> = emptyList(),
+    val monthTitle: String = ""
+)
 
 sealed class HistoryEvent {
     data class NavigateToQuestionDetail(val question: Question) : HistoryEvent()
@@ -70,7 +80,58 @@ class HistoryViewModel @Inject constructor(
     val events: SharedFlow<HistoryEvent> = _events.asSharedFlow()
 
     init {
+        // 초기 monthTitle/calendarDays 도 stored 로 미리 계산
+        val initialMonth = _uiState.value.currentMonth
+        _uiState.update {
+            it.copy(
+                monthTitle = computeMonthTitle(initialMonth),
+                calendarDays = computeCalendarDays(initialMonth)
+            )
+        }
         loadHistory()
+    }
+
+    /** iOS MG-59 패리티 — 42 셀 사전 계산 */
+    private fun computeCalendarDays(month: Date): List<CalendarDayInfo?> {
+        val firstOfMonth = Calendar.getInstance().apply {
+            time = month
+            set(Calendar.DAY_OF_MONTH, 1)
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+        }
+        val firstDayOfWeek = firstOfMonth.get(Calendar.DAY_OF_WEEK) - 1   // 0=일요일
+        val daysInMonth = firstOfMonth.getActualMaximum(Calendar.DAY_OF_MONTH)
+
+        val today = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+        }.timeInMillis
+
+        val days = ArrayList<CalendarDayInfo?>(42)
+        repeat(firstDayOfWeek) { days.add(null) }
+        val cal = Calendar.getInstance().apply {
+            time = firstOfMonth.time
+        }
+        repeat(daysInMonth) { i ->
+            cal.set(Calendar.DAY_OF_MONTH, i + 1)
+            val dayMillis = cal.timeInMillis
+            days.add(
+                CalendarDayInfo(
+                    date = cal.time,
+                    dayString = (i + 1).toString(),
+                    weekday = cal.get(Calendar.DAY_OF_WEEK),
+                    isCurrentMonth = true,
+                    isToday = dayMillis == today
+                )
+            )
+        }
+        while (days.size < 42) days.add(null)
+        return days
+    }
+
+    private fun computeMonthTitle(month: Date): String {
+        val cal = Calendar.getInstance().apply { time = month }
+        return "${cal.get(Calendar.YEAR)}년 ${cal.get(Calendar.MONTH) + 1}월"
     }
 
     private fun loadHistory() {
@@ -173,13 +234,27 @@ class HistoryViewModel @Inject constructor(
     fun previousMonth() {
         val cal = Calendar.getInstance().apply { time = _uiState.value.currentMonth }
         cal.add(Calendar.MONTH, -1)
-        _uiState.update { it.copy(currentMonth = cal.time) }
+        val newMonth = cal.time
+        _uiState.update {
+            it.copy(
+                currentMonth = newMonth,
+                monthTitle = computeMonthTitle(newMonth),
+                calendarDays = computeCalendarDays(newMonth)
+            )
+        }
     }
 
     fun nextMonth() {
         val cal = Calendar.getInstance().apply { time = _uiState.value.currentMonth }
         cal.add(Calendar.MONTH, 1)
-        _uiState.update { it.copy(currentMonth = cal.time) }
+        val newMonth = cal.time
+        _uiState.update {
+            it.copy(
+                currentMonth = newMonth,
+                monthTitle = computeMonthTitle(newMonth),
+                calendarDays = computeCalendarDays(newMonth)
+            )
+        }
     }
 
     fun onItemTapped(item: HistoryItem) {

--- a/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
@@ -110,10 +110,13 @@ class QuestionDetailViewModel @Inject constructor(
                 }
 
                 val members = _uiState.value.familyMembers
+                // O(F + A) — answer 마다 O(F) firstOrNull 선형 탐색하던 nested loop 를
+                // dict 인덱스 1회 구축으로 대체 (iOS MG-68 패리티).
+                val memberById = members.associateBy { it.id }
                 val familyAnswers = allAnswers
                     .filter { it.userId != currentUser?.id }
                     .mapNotNull { answer ->
-                        val user = members.firstOrNull { it.id == answer.userId }
+                        val user = memberById[answer.userId]
                         user?.let { FamilyAnswer(user = it, answer = answer) }
                     }
 

--- a/app/src/main/java/com/mongle/android/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/search/SearchScreen.kt
@@ -209,10 +209,7 @@ fun SearchScreen(
             }
 
             uiState.results.isNotEmpty() -> {
-                // 플랫 리스트로 변환하여 11개마다 광고 삽입 (iOS 동일)
-                val flatResults = uiState.results
-                val totalCount = flatResults.size
-
+                // iOS MG-60 패리티 — ViewModel 사전 계산 groupedResults / adAnchorIds 소비
                 LazyColumn(
                     modifier = Modifier
                         .fillMaxSize()
@@ -229,17 +226,14 @@ fun SearchScreen(
                         Spacer(modifier = Modifier.height(MongleSpacing.md))
                     }
 
-                    // 날짜별 그룹핑
-                    val grouped = uiState.results.groupBy { it.date.toDateKey() }
-                    var globalIndex = 0
-                    grouped.entries.sortedByDescending { it.key }.forEach { (_, items) ->
-                        item {
-                            DateGroupHeader(date = items.first().date)
+                    // iOS MG-60 패리티 — ViewModel 사전 계산 groupedResults / adAnchorIds 사용.
+                    // 매 렌더링마다 groupBy + sortedByDescending + DateFormatter 재실행하던 비용 제거.
+                    uiState.groupedResults.forEach { section ->
+                        item(key = "header_${section.dateKey}") {
+                            DateGroupHeaderPrecomputed(displayLabel = section.displayLabel)
                             Spacer(modifier = Modifier.height(MongleSpacing.sm))
                         }
-                        items.forEach { result ->
-                            val currentIndex = globalIndex
-                            globalIndex++
+                        section.items.forEach { result ->
                             item(key = result.dailyQuestionId) {
                                 SearchResultCard(
                                     result = result,
@@ -247,16 +241,16 @@ fun SearchScreen(
                                 )
                                 Spacer(modifier = Modifier.height(MongleSpacing.sm))
                             }
-                            // 11개마다 또는 마지막 아이템 뒤에 광고 배너 삽입
-                            if ((currentIndex + 1) % 11 == 0 || currentIndex + 1 == totalCount) {
-                                item(key = "ad_$currentIndex") {
+                            // O(1) Set lookup
+                            if (uiState.adAnchorIds.contains(result.dailyQuestionId)) {
+                                item(key = "ad_${result.dailyQuestionId}") {
                                     AdBannerSection(
                                         modifier = Modifier.padding(vertical = MongleSpacing.sm)
                                     )
                                 }
                             }
                         }
-                        item { Spacer(modifier = Modifier.height(MongleSpacing.xs)) }
+                        item(key = "spacer_${section.dateKey}") { Spacer(modifier = Modifier.height(MongleSpacing.xs)) }
                     }
                     item { Spacer(modifier = Modifier.height(MongleSpacing.xl)) }
                 }
@@ -280,7 +274,7 @@ fun SearchScreen(
 }
 
 @Composable
-private fun DateGroupHeader(date: Date) {
+private fun DateGroupHeaderPrecomputed(displayLabel: String) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
@@ -292,7 +286,7 @@ private fun DateGroupHeader(date: Date) {
             modifier = Modifier.size(13.dp)
         )
         Text(
-            text = date.toDisplayLabel(),
+            text = displayLabel,
             style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
             color = MongleTextHint
         )
@@ -446,13 +440,3 @@ private fun buildHighlightedText(text: String, query: String) = buildAnnotatedSt
     }
 }
 
-private fun Date.toDateKey(): Long {
-    val cal = Calendar.getInstance().apply {
-        time = this@toDateKey
-        set(Calendar.HOUR_OF_DAY, 0)
-        set(Calendar.MINUTE, 0)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-    }
-    return cal.timeInMillis
-}

--- a/app/src/main/java/com/mongle/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/search/SearchViewModel.kt
@@ -34,9 +34,25 @@ data class SearchResultItem(
     val totalAnswerCount: Int
 )
 
+/**
+ * 날짜 그룹별 사전 계산 섹션 (iOS MG-60 패리티).
+ * LazyColumn body 안에서 매 렌더링마다 groupBy + sortedByDescending + DateFormatter 호출하던 비용을
+ * 검색 1회 시점에만 계산해 stored 한다.
+ */
+data class SearchResultSection(
+    val dateKey: Long,
+    val date: Date,
+    val displayLabel: String,
+    val items: List<SearchResultItem>
+)
+
 data class SearchUiState(
     val query: String = "",
     val results: List<SearchResultItem> = emptyList(),
+    /** 그룹별 사전 정렬·displayLabel 캐시 — Screen 에서 groupBy 호출 회피 */
+    val groupedResults: List<SearchResultSection> = emptyList(),
+    /** (currentIndex + 1) % 11 == 0 또는 마지막 anchor 의 dailyQuestionId — Screen 에서 O(1) lookup */
+    val adAnchorIds: Set<String> = emptySet(),
     val isLoading: Boolean = false,
     val showMinLengthHint: Boolean = false,
     val errorMessage: String? = null
@@ -125,7 +141,7 @@ class SearchViewModel @Inject constructor(
     private fun performSearch(query: String) {
         val trimmed = query.trim()
         if (trimmed.length < 2) {
-            _uiState.update { it.copy(results = emptyList()) }
+            _uiState.update { it.copy(results = emptyList(), groupedResults = emptyList(), adAnchorIds = emptySet()) }
             return
         }
         // 아직 히스토리 로딩 중이면 결과를 비우지 않고 대기 (로드 완료 후 재검색)
@@ -178,7 +194,39 @@ class SearchViewModel @Inject constructor(
         // 날짜 내림차순 정렬
         results.sortByDescending { it.date }
 
-        _uiState.update { it.copy(results = results) }
+        // iOS MG-60 패리티: 그룹핑/displayLabel/광고 anchor 를 검색 1회 시점에 사전 계산.
+        val sections = makeSections(results)
+        val anchors = makeAdAnchorIds(results)
+
+        _uiState.update {
+            it.copy(results = results, groupedResults = sections, adAnchorIds = anchors)
+        }
+    }
+
+    private fun makeSections(results: List<SearchResultItem>): List<SearchResultSection> {
+        if (results.isEmpty()) return emptyList()
+        val grouped = results.groupBy { it.date.toDateKeyMillis() }
+        return grouped.entries.sortedByDescending { it.key }.map { (key, items) ->
+            val firstDate = items.first().date
+            SearchResultSection(
+                dateKey = key,
+                date = firstDate,
+                displayLabel = firstDate.toDisplayLabel(),
+                items = items
+            )
+        }
+    }
+
+    private fun makeAdAnchorIds(results: List<SearchResultItem>): Set<String> {
+        if (results.isEmpty()) return emptySet()
+        val total = results.size
+        val anchors = HashSet<String>(total / 11 + 2)
+        results.forEachIndexed { i, r ->
+            if ((i + 1) % 11 == 0 || i + 1 == total) {
+                anchors.add(r.dailyQuestionId)
+            }
+        }
+        return anchors
     }
 
     fun clearError() {
@@ -204,6 +252,16 @@ class SearchViewModel @Inject constructor(
  */
 private fun String.normalizedForSearch(): String =
     Normalizer.normalize(this, Normalizer.Form.NFC).lowercase()
+
+/** Date 자정 정규화 millis 키 (그룹핑용) */
+private fun Date.toDateKeyMillis(): Long {
+    val cal = Calendar.getInstance().apply {
+        time = this@toDateKeyMillis
+        set(Calendar.HOUR_OF_DAY, 0); set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0); set(Calendar.MILLISECOND, 0)
+    }
+    return cal.timeInMillis
+}
 
 /** Date를 표시 문자열로 포맷 (오늘/어제/날짜) */
 fun Date.toDisplayLabel(): String {


### PR DESCRIPTION
## Jira
- [MG-87](https://ycompany.atlassian.net/browse/MG-87)

## Related
- iOS 패리티: MG-59/60/68

## Summary
- HistoryViewModel/Screen: CalendarDayInfo + 사전 계산 캐시
- SearchViewModel/Screen: SearchResultSection + 그룹핑/displayLabel 캐시
- QuestionDetailViewModel: associateBy dict O(1) lookup

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)