### PR TITLE
fix(hearts): 작성/스킵 비용 서버 정책 기반 동적화 (MG-88, MG-84 follow-up)

### DIFF
--- a/app/src/main/java/com/mongle/android/data/remote/ApiAuthRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ApiAuthRepository.kt
@@ -59,7 +59,9 @@ class ApiAuthRepository @Inject constructor(
         hearts = hearts,
         moodId = moodId,
         createdAt = Date(),
-        heartGrantedToday = heartGrantedToday ?: false
+        heartGrantedToday = heartGrantedToday ?: false,
+        heartsWriteCost = heartsWriteCost,
+        heartsSkipCost = heartsSkipCost
     )
 
     private suspend fun <T> safeCall(block: suspend () -> T): T {

--- a/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
@@ -47,7 +47,13 @@ data class ApiUserResponse(
      * users/me?grantDailyHeart=true 호출 시에만 서버가 set 하며, 이미 받은 날에는 false.
      * 미지원 서버 호환을 위해 nullable.
      */
-    val heartGrantedToday: Boolean? = null
+    val heartGrantedToday: Boolean? = null,
+    /**
+     * 서버 정책 기반 하트 비용. 미지원 서버에서는 클라 기본값(3) 사용.
+     * (iOS MG-84 follow-up 패리티)
+     */
+    val heartsWriteCost: Int = 3,
+    val heartsSkipCost: Int = 3
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/mongle/android/domain/model/User.kt
+++ b/app/src/main/java/com/mongle/android/domain/model/User.kt
@@ -14,7 +14,10 @@ data class User(
     val createdAt: Date,
     val lastNameChangedAt: Long? = null,
     /** users/me?grantDailyHeart=true 응답에서만 true 가 올 수 있음 */
-    val heartGrantedToday: Boolean = false
+    val heartGrantedToday: Boolean = false,
+    /** 서버 정책에 따른 하트 비용 (기본값 3, iOS MG-84 follow-up) */
+    val heartsWriteCost: Int = 3,
+    val heartsSkipCost: Int = 3
 )
 
 enum class FamilyRole(val displayName: String) {

--- a/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
@@ -503,14 +503,15 @@ fun HomeScreen(
         }
     }
 
-    // 나만의 질문 작성하기 확인 팝업
+    // 나만의 질문 작성하기 확인 팝업 — iOS MG-84 follow-up: 서버 정책 기반 비용 동적 참조
     if (showWriteConfirmDialog) {
         val currentHearts = uiState.currentUser?.hearts ?: 0
+        val writeCost = uiState.currentUser?.heartsWriteCost ?: 3
         Dialog(
             onDismissRequest = { showWriteConfirmDialog = false },
             properties = DialogProperties(usePlatformDefaultWidth = false)
         ) {
-            if (currentHearts >= 3) {
+            if (currentHearts >= writeCost) {
                 MonglePopup(
                     title = stringResource(R.string.home_write_question_title),
                     description = stringResource(R.string.home_write_question_desc),
@@ -540,14 +541,15 @@ fun HomeScreen(
         }
     }
 
-    // 질문 넘기기 확인 팝업
+    // 질문 넘기기 확인 팝업 — iOS MG-84 follow-up: 서버 정책 기반 비용 동적 참조
     if (showSkipConfirmDialog) {
         val currentHearts = uiState.currentUser?.hearts ?: 0
+        val skipCost = uiState.currentUser?.heartsSkipCost ?: 3
         Dialog(
             onDismissRequest = { showSkipConfirmDialog = false },
             properties = DialogProperties(usePlatformDefaultWidth = false)
         ) {
-            if (currentHearts >= 3) {
+            if (currentHearts >= skipCost) {
                 MonglePopup(
                     title = stringResource(R.string.home_skip_question_title),
                     description = stringResource(R.string.home_skip_question_desc),


### PR DESCRIPTION
## Jira
- [MG-88](https://ycompany.atlassian.net/browse/MG-88) — MG-84 follow-up

## Summary
- ApiUserResponse / User domain: heartsWriteCost / heartsSkipCost (기본 3)
- HomeScreen 작성·스킵 확인 팝업: 동적 참조

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)