### PR TITLE
fix(auth): sessionExpired 재로그인 안내 팝업 (MG-89)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
+++ b/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.res.stringResource
+import com.ycompany.Monggle.R
 import com.mongle.android.ui.common.MonglePopup
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -121,6 +123,22 @@ fun MongleNavHost(
             }
         }
         rootViewModel.clearPendingNotification()
+    }
+
+    // iOS MG-33 패리티 — 토큰 만료(401+refresh 실패) 시 사용자 친화 안내 팝업.
+    // appState 분기와 무관하게 노출되어야 함(이동 직후 Unauthenticated 화면 위로 띄움).
+    if (uiState.showSessionExpiredPopup) {
+        Dialog(
+            onDismissRequest = { rootViewModel.dismissSessionExpiredPopup() },
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            MonglePopup(
+                title = stringResource(R.string.session_expired_title),
+                description = stringResource(R.string.session_expired_desc),
+                primaryLabel = stringResource(R.string.session_expired_action),
+                onPrimary = { rootViewModel.dismissSessionExpiredPopup() }
+            )
+        }
     }
 
     when (uiState.appState) {

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -62,7 +62,12 @@ data class RootUiState(
     val pendingAppleCallbackUri: android.net.Uri? = null,
     /** 동의 화면에 전달할 컨텍스트 (로그인 응답에서 받음) */
     val pendingConsentRequired: List<LegalDocType> = emptyList(),
-    val pendingLegalVersions: LegalVersions = LegalVersions(terms = "", privacy = "")
+    val pendingLegalVersions: LegalVersions = LegalVersions(terms = "", privacy = ""),
+    /**
+     * 토큰 만료(401+refresh 실패) 시 사용자에게 "다시 로그인이 필요해요" 안내를 노출.
+     * iOS MG-33 패리티. 무음 로그아웃 회피.
+     */
+    val showSessionExpiredPopup: Boolean = false
 )
 
 @HiltViewModel
@@ -101,12 +106,22 @@ class RootViewModel @Inject constructor(
 
     init {
         checkAuthStatus()
-        // 토큰 만료(401 + 갱신 실패) 이벤트 구독 → 로그인 화면으로 이동
+        // 토큰 만료(401 + 갱신 실패) 이벤트 구독 → 안내 팝업 + 로그인 화면 (iOS MG-33 패리티)
         viewModelScope.launch {
             sessionExpiredNotifier.events.collect {
-                _uiState.update { RootUiState(appState = AppState.Unauthenticated) }
+                _uiState.update {
+                    RootUiState(
+                        appState = AppState.Unauthenticated,
+                        showSessionExpiredPopup = true
+                    )
+                }
             }
         }
+    }
+
+    /** sessionExpired 안내 팝업 닫기 */
+    fun dismissSessionExpiredPopup() {
+        _uiState.update { it.copy(showSessionExpiredPopup = false) }
     }
 
     private fun checkAuthStatus() {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -5,6 +5,9 @@
 
     <!-- Common -->
     <string name="common_confirm">確認</string>
+    <string name="session_expired_title">再度ログインが必要です</string>
+    <string name="session_expired_desc">セキュリティのため自動的にログアウトされました。\n再度ログインしてください。</string>
+    <string name="session_expired_action">ログイン</string>
     <string name="common_cancel">キャンセル</string>
     <string name="common_back">戻る</string>
     <string name="common_next">次へ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -5,6 +5,9 @@
 
     <!-- Common -->
     <string name="common_confirm">확인</string>
+    <string name="session_expired_title">다시 로그인이 필요해요</string>
+    <string name="session_expired_desc">보안을 위해 로그아웃되었어요.\n다시 로그인해 주세요.</string>
+    <string name="session_expired_action">로그인하기</string>
     <string name="common_cancel">취소</string>
     <string name="common_back">뒤로</string>
     <string name="common_next">다음</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,9 @@
 
     <!-- Common -->
     <string name="common_confirm">OK</string>
+    <string name="session_expired_title">Please log in again</string>
+    <string name="session_expired_desc">For security reasons, you have been logged out.\nPlease log in again.</string>
+    <string name="session_expired_action">Log in</string>
     <string name="common_cancel">Cancel</string>
     <string name="common_back">Back</string>
     <string name="common_next">Next</string>


### PR DESCRIPTION
## Jira
- [MG-89](https://ycompany.atlassian.net/browse/MG-89)

## Related
- iOS 패리티: MG-33 (+ MG-31 가드는 기존 코드로 동등 보호 확인)

## Summary
- RootUiState.showSessionExpiredPopup
- sessionExpiredNotifier collect 에서 set
- Dialog overlay + i18n strings (ko/en/ja)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)