### PR TITLE
fix(auth): 토큰·광고 race 안정화 (MG-90)

### DIFF
--- a/app/src/main/java/com/mongle/android/data/remote/AdRewardClient.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/AdRewardClient.kt
@@ -1,0 +1,34 @@
+package com.mongle.android.data.remote
+
+import kotlinx.coroutines.delay
+
+/**
+ * 광고 보상 grantAdHearts 호출에 exponential backoff retry 적용 (iOS MG-34 패리티).
+ *
+ * 사용자가 광고를 끝까지 시청했음에도 transient 네트워크 오류로 보상이 누락되는 것을
+ * 방지하기 위해 최대 3회 재시도(500ms / 1s / 2s).
+ *
+ * 사용처: HomeViewModel.watchAdForWrite/Skip, QuestionDetailViewModel.watchAdForEdit,
+ * PeerNudgeViewModel.watchAdForNudge.
+ */
+object AdRewardClient {
+    suspend fun grantAdHearts(
+        repository: ApiUserRepository,
+        amount: Int,
+        maxRetries: Int = 3
+    ): Int {
+        var lastError: Throwable? = null
+        for (attempt in 0 until maxRetries) {
+            try {
+                return repository.grantAdHearts(amount)
+            } catch (e: Throwable) {
+                lastError = e
+                if (attempt < maxRetries - 1) {
+                    val backoffMs = 500L * (1 shl attempt) // 500, 1000, 2000
+                    delay(backoffMs)
+                }
+            }
+        }
+        throw lastError ?: Exception("ad reward grant failed")
+    }
+}

--- a/app/src/main/java/com/mongle/android/data/remote/ApiAuthRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ApiAuthRepository.kt
@@ -191,8 +191,14 @@ class ApiAuthRepository @Inject constructor(
     }
 
     override suspend fun deleteAccount() {
-        safeCall { api.deleteAccount() }
-        clearSession()
+        // iOS MG-35 패리티 — API 호출 성공/실패와 무관하게 로컬 세션 정리.
+        // 이전에는 safeCall 이 throw 하면 clearSession() 이 실행되지 않아
+        // 잔존 토큰으로 다음 사용자가 이전 계정 데이터에 접근할 위험이 있었음.
+        try {
+            safeCall { api.deleteAccount() }
+        } finally {
+            clearSession()
+        }
     }
 
     override suspend fun getCurrentUser(grantDailyHeart: Boolean): User? {

--- a/app/src/main/java/com/mongle/android/data/remote/TokenAuthenticator.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/TokenAuthenticator.kt
@@ -11,6 +11,8 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.Route
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -43,6 +45,11 @@ class TokenAuthenticator @Inject constructor(
         moshi.adapter(TokenRefreshResponse::class.java)
     }
 
+    // iOS MG-35 패리티 — 동시 401 발생 시 refresh 가 한 번만 일어나도록 보호한다.
+    // OkHttp 가 여러 동시 401 에 대해 authenticate() 를 동시에 호출할 수 있어
+    // refresh 토큰을 동일 값으로 여러 번 사용하면 일부 응답이 invalid 처리될 위험이 있음.
+    private val refreshLock = ReentrantLock()
+
     override fun authenticate(route: Route?, response: Response): Request? {
         // 이미 한 번 재시도했으면 포기 (무한루프 방지)
         if (response.priorResponse != null) {
@@ -53,7 +60,8 @@ class TokenAuthenticator @Inject constructor(
         // 첫 설치 직후 또는 로그아웃 직후처럼 refresh 토큰이 SharedPreferences 에 한 번도
         // 들어간 적 없는 상태에서는 sessionExpired 신호를 발화하지 않는다.
         // 발화하면 RootViewModel 이 "세션 만료"로 라우팅돼 사용자에게 불필요한 재로그인 안내가 노출됨.
-        val refreshToken = prefs.getString(AUTH_KEY_REFRESH_TOKEN, null) ?: run {
+        val incomingToken = prefs.getString(AUTH_KEY_TOKEN, null)
+        val initialRefresh = prefs.getString(AUTH_KEY_REFRESH_TOKEN, null) ?: run {
             if (prefs.contains(AUTH_KEY_REFRESH_TOKEN)) {
                 notifyAndClear()
             } else {
@@ -62,6 +70,21 @@ class TokenAuthenticator @Inject constructor(
             return null
         }
 
+        return refreshLock.withLock {
+            // 다른 스레드가 이미 갱신해 둔 액세스 토큰이 있으면 그걸 그대로 재사용한다.
+            // 요청을 보낸 시점의 access 토큰과 현재 저장된 access 토큰이 다르면 이미 갱신된 상태.
+            val currentToken = prefs.getString(AUTH_KEY_TOKEN, null)
+            if (currentToken != null && currentToken != incomingToken) {
+                return@withLock response.request.newBuilder()
+                    .header("Authorization", "Bearer $currentToken")
+                    .build()
+            }
+
+            performRefresh(initialRefresh, response)
+        }
+    }
+
+    private fun performRefresh(refreshToken: String, response: Response): Request? {
         return try {
             val body = """{"refresh_token":"$refreshToken"}"""
                 .toRequestBody("application/json".toMediaType())

--- a/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
@@ -434,7 +434,8 @@ class HomeViewModel @Inject constructor(
             onRewarded = {
                 viewModelScope.launch {
                     try {
-                        val heartsAfterAd = userRepository.grantAdHearts(3)
+                        // iOS MG-34 패리티 — AdRewardClient retry 적용
+                        val heartsAfterAd = com.mongle.android.data.remote.AdRewardClient.grantAdHearts(userRepository, 3)
                         _uiState.update {
                             it.copy(
                                 isLoading = false,
@@ -464,7 +465,8 @@ class HomeViewModel @Inject constructor(
             onRewarded = {
                 viewModelScope.launch {
                     try {
-                        val heartsAfterAd = userRepository.grantAdHearts(3)
+                        // iOS MG-34 패리티 — AdRewardClient retry 적용
+                        val heartsAfterAd = com.mongle.android.data.remote.AdRewardClient.grantAdHearts(userRepository, 3)
                         _uiState.update {
                             it.copy(currentUser = it.currentUser?.copy(hearts = heartsAfterAd))
                         }

--- a/app/src/main/java/com/mongle/android/ui/nudge/PeerNudgeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/nudge/PeerNudgeViewModel.kt
@@ -77,7 +77,8 @@ class PeerNudgeViewModel @Inject constructor(
             onRewarded = {
                 viewModelScope.launch {
                     try {
-                        val heartsAfterAd = userRepository.grantAdHearts(1)
+                        // iOS MG-34 패리티 — AdRewardClient retry 적용
+                        val heartsAfterAd = com.mongle.android.data.remote.AdRewardClient.grantAdHearts(userRepository, 1)
                         _uiState.update { it.copy(hearts = heartsAfterAd, isWatchingAd = false) }
                         val heartsRemaining = nudgeRepository.sendNudge(state.targetUserId)
                         _uiState.update {

--- a/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.mongle.android.ui.question
 import androidx.lifecycle.ViewModel
 import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
+import com.mongle.android.data.remote.AdRewardClient
 import com.mongle.android.data.remote.ApiUserRepository
 import com.mongle.android.domain.model.Answer
 import com.mongle.android.domain.model.Question
@@ -179,8 +180,15 @@ class QuestionDetailViewModel @Inject constructor(
     }
 
     fun confirmEditAnswer() {
-        _uiState.update { it.copy(showEditConfirmDialog = false) }
-        doSubmitAnswer()
+        // iOS MG-34 패리티 — 수정 비용 1 하트를 옵티미스틱 차감해 UI 즉시 피드백.
+        // doSubmitAnswer() catch 블록에서 실패 시 +1 rollback.
+        _uiState.update {
+            it.copy(
+                showEditConfirmDialog = false,
+                hearts = (it.hearts - 1).coerceAtLeast(0)
+            )
+        }
+        doSubmitAnswer(isEditOptimistic = true)
     }
 
     fun dismissEditAdDialog() {
@@ -195,10 +203,22 @@ class QuestionDetailViewModel @Inject constructor(
             onRewarded = {
                 viewModelScope.launch {
                     try {
-                        val heartsAfterAd = userRepository.grantAdHearts(1)
-                        _uiState.update { it.copy(hearts = heartsAfterAd, isWatchingAd = false) }
-                        // 광고 시청 후 바로 수정 실행
-                        doSubmitAnswer()
+                        // iOS MG-34 패리티 — transient 오류 시에도 보상 누락 방지 (3회 retry)
+                        val heartsAfterAd = AdRewardClient.grantAdHearts(userRepository, 1)
+                        // iOS MG-34 패리티 — 다른 단말에서 동시에 하트를 사용한 경우를 대비해 재검증.
+                        if (heartsAfterAd >= 1) {
+                            // 옵티미스틱 차감 후 수정 실행
+                            _uiState.update { it.copy(hearts = heartsAfterAd - 1, isWatchingAd = false) }
+                            doSubmitAnswer(isEditOptimistic = true)
+                        } else {
+                            _uiState.update {
+                                it.copy(
+                                    hearts = heartsAfterAd,
+                                    isWatchingAd = false,
+                                    errorMessage = "다른 단말에서 하트를 사용했어요. 다시 시도해주세요."
+                                )
+                            }
+                        }
                     } catch (e: Exception) {
                         _uiState.update { it.copy(isWatchingAd = false, errorMessage = AppError.from(e).toastMessage) }
                     }
@@ -210,7 +230,11 @@ class QuestionDetailViewModel @Inject constructor(
         )
     }
 
-    private fun doSubmitAnswer() {
+    /**
+     * @param isEditOptimistic confirmEditAnswer / watchAdForEdit 진입 시 hearts 를 미리
+     *   -1 차감했음을 알리는 플래그. 실패 시 +1 rollback.
+     */
+    private fun doSubmitAnswer(isEditOptimistic: Boolean = false) {
         val state = _uiState.value
         val question = state.question ?: return
         val userId = state.currentUser?.id ?: return
@@ -244,7 +268,12 @@ class QuestionDetailViewModel @Inject constructor(
                 _events.emit(QuestionDetailEvent.AnswerSubmitted(savedAnswer, isNewAnswer))
             } catch (e: Exception) {
                 _uiState.update {
-                    it.copy(isSubmitting = false, errorMessage = AppError.from(e).toastMessage)
+                    it.copy(
+                        isSubmitting = false,
+                        errorMessage = AppError.from(e).toastMessage,
+                        // 옵티미스틱 차감했던 hearts 복구 (iOS MG-34 패리티)
+                        hearts = if (isEditOptimistic) it.hearts + 1 else it.hearts
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -104,6 +104,10 @@ class RootViewModel @Inject constructor(
     // 서버 활성 그룹과 클라이언트 활성 그룹이 어긋나는 race 를 차단한다.
     private var groupSelectionJob: Job? = null
 
+    // iOS MG-37 패리티 — scenePhase 빠른 반복(백그라운드↔포그라운드)으로 loadHomeData 가
+    // 누적 호출되는 것을 차단. 다음 진입 시 이전 in-flight 호출 cancel.
+    private var loadHomeDataJob: Job? = null
+
     init {
         checkAuthStatus()
         // 토큰 만료(401 + 갱신 실패) 이벤트 구독 → 안내 팝업 + 로그인 화면 (iOS MG-33 패리티)
@@ -157,7 +161,8 @@ class RootViewModel @Inject constructor(
     }
 
     fun loadHomeData() {
-        viewModelScope.launch {
+        loadHomeDataJob?.cancel()
+        loadHomeDataJob = viewModelScope.launch {
             try {
                 val familyResult = runCatching { mongleRepository.getMyFamily() }.getOrNull()
                 val family = familyResult?.first
@@ -366,11 +371,19 @@ class RootViewModel @Inject constructor(
 
     fun logout() {
         groupSelectionJob?.cancel()
+        loadHomeDataJob?.cancel()
         viewModelScope.launch {
             runCatching { authRepository.logout() }
             clearUserScopedPrefs()
+            // iOS MG-37 패리티 — pending 신호 명시 정리. RootUiState() 새 인스턴스로
+            // default null 이 자동 적용되지만 명시적으로 의도를 드러낸다.
             _uiState.update {
-                RootUiState(appState = AppState.Unauthenticated)
+                RootUiState(
+                    appState = AppState.Unauthenticated,
+                    pendingInviteCode = null,
+                    pendingNotificationType = null,
+                    pendingAppleCallbackUri = null
+                )
             }
         }
     }


### PR DESCRIPTION
## Jira
- [MG-90](https://ycompany.atlassian.net/browse/MG-90)

## Related
- iOS 패리티: MG-34 / MG-35 / MG-37

## Summary
- AdRewardClient 신규 (3회 retry)
- TokenAuthenticator mutex
- deleteAccount finally
- QuestionDetailVM 옵티미스틱+rollback + 광고 후 hearts 재검증
- RootViewModel loadHomeDataJob cancel + logout pending cleanup

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)