### PR TITLE
i18n: DateFormatter 한국어 하드코딩 제거 — Locale.getDefault() (MG-91)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/history/HistoryViewModel.kt
@@ -129,9 +129,15 @@ class HistoryViewModel @Inject constructor(
         return days
     }
 
+    /** iOS MG-38 패리티 — 시스템 로케일 기반 월 제목 포맷 */
     private fun computeMonthTitle(month: Date): String {
-        val cal = Calendar.getInstance().apply { time = month }
-        return "${cal.get(Calendar.YEAR)}년 ${cal.get(Calendar.MONTH) + 1}월"
+        val locale = java.util.Locale.getDefault()
+        val pattern = when (locale.language) {
+            "ko" -> "yyyy년 M월"
+            "ja" -> "yyyy年M月"
+            else -> "MMMM yyyy"
+        }
+        return java.text.SimpleDateFormat(pattern, locale).format(month)
     }
 
     private fun loadHistory() {

--- a/app/src/main/java/com/mongle/android/ui/home/PeerAnswerSheet.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/PeerAnswerSheet.kt
@@ -138,7 +138,8 @@ fun PeerAnswerSheet(
                                 color = MongleTextPrimary
                             )
                             val timeStr = runCatching {
-                                SimpleDateFormat("MM/dd HH:mm", Locale.KOREAN).format(answer.createdAt)
+                                // iOS MG-38 패리티 — 시스템 로케일 사용 (ko/en/ja 대응)
+                                SimpleDateFormat("MM/dd HH:mm", Locale.getDefault()).format(answer.createdAt)
                             }.getOrElse { "" }
                             if (timeStr.isNotEmpty()) {
                                 Text(

--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
@@ -483,6 +483,15 @@ private fun timeAgo(createdAt: String, res: Resources): String {
         diffMin < 60 -> res.getString(R.string.notif_time_min, diffMin.toInt())
         diffHours < 24 -> res.getString(R.string.notif_time_hour, diffHours.toInt())
         diffDays < 7 -> res.getString(R.string.notif_time_day, diffDays.toInt())
-        else -> SimpleDateFormat("M/d", Locale.getDefault()).format(date)
+        else -> {
+            // iOS MG-38 패리티 — 7일 이상 fallback 도 로케일 분기
+            val locale = Locale.getDefault()
+            val pattern = when (locale.language) {
+                "ko" -> "M월 d일"
+                "ja" -> "M月d日"
+                else -> "M/d"
+            }
+            SimpleDateFormat(pattern, locale).format(date)
+        }
     }
 }

--- a/app/src/main/java/com/mongle/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/search/SearchViewModel.kt
@@ -263,18 +263,27 @@ private fun Date.toDateKeyMillis(): Long {
     return cal.timeInMillis
 }
 
-/** Date를 표시 문자열로 포맷 (오늘/어제/날짜) */
+/** Date를 표시 문자열로 포맷 (오늘/어제/날짜) — 시스템 로케일 기반 i18n (iOS MG-38 패리티) */
 fun Date.toDisplayLabel(): String {
+    val locale = java.util.Locale.getDefault()
+    val pattern = when (locale.language) {
+        "ko" -> "M월 d일"
+        "ja" -> "M月d日"
+        else -> "MMM d"
+    }
+    val datePart = java.text.SimpleDateFormat(pattern, locale).format(this)
+
     val cal = Calendar.getInstance().apply { time = this@toDisplayLabel }
     val today = Calendar.getInstance()
     val yesterday = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, -1) }
-    return when {
+    val suffix = when {
         cal.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
             cal.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR) ->
-            "${cal.get(Calendar.MONTH) + 1}월 ${cal.get(Calendar.DAY_OF_MONTH)}일 · 오늘"
+            when (locale.language) { "ko" -> " · 오늘"; "ja" -> " · 今日"; else -> " · Today" }
         cal.get(Calendar.YEAR) == yesterday.get(Calendar.YEAR) &&
             cal.get(Calendar.DAY_OF_YEAR) == yesterday.get(Calendar.DAY_OF_YEAR) ->
-            "${cal.get(Calendar.MONTH) + 1}월 ${cal.get(Calendar.DAY_OF_MONTH)}일 · 어제"
-        else -> "${cal.get(Calendar.MONTH) + 1}월 ${cal.get(Calendar.DAY_OF_MONTH)}일"
+            when (locale.language) { "ko" -> " · 어제"; "ja" -> " · 昨日"; else -> " · Yesterday" }
+        else -> ""
     }
+    return "$datePart$suffix"
 }


### PR DESCRIPTION
## Jira
- [MG-91](https://ycompany.atlassian.net/browse/MG-91)

## Related
- iOS 패리티: MG-38

## Summary
- 4 위치 로케일 분기 적용

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)