### PR TITLE
fix(MG-93,94,95,105): 네트워크/보안 강화

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,9 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
 
+    // MG-95 EncryptedSharedPreferences — 토큰/PII 평문 저장 제거
+    implementation(libs.androidx.security.crypto)
+
     // Network
     implementation(libs.retrofit)
     implementation(libs.retrofit.converter.moshi)

--- a/app/src/main/java/com/mongle/android/data/remote/ApiAuthRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ApiAuthRepository.kt
@@ -1,6 +1,6 @@
 package com.mongle.android.data.remote
 
-import android.content.Context
+import android.content.SharedPreferences
 import android.util.Log
 import com.mongle.android.domain.model.FamilyRole
 import com.mongle.android.domain.model.LegalDocType
@@ -10,14 +10,13 @@ import com.mongle.android.domain.model.SocialLoginResult
 import com.mongle.android.domain.model.SocialProviderType
 import com.mongle.android.domain.model.User
 import com.mongle.android.domain.repository.AuthRepository
-import dagger.hilt.android.qualifiers.ApplicationContext
 import retrofit2.HttpException
 import java.util.Date
 import java.util.UUID
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
-private const val PREF_NAME = "mongle_auth"
 private const val KEY_TOKEN = "auth_token"
 private const val KEY_REFRESH_TOKEN = "refresh_token"
 private const val KEY_USER_ID = "user_id"
@@ -28,12 +27,9 @@ private const val KEY_USER_ROLE = "user_role"
 @Singleton
 class ApiAuthRepository @Inject constructor(
     private val api: MongleApiService,
-    @ApplicationContext private val context: Context
+    // MG-95 EncryptedSharedPreferences 인스턴스를 SecurityModule 에서 주입.
+    @Named("auth") private val prefs: SharedPreferences
 ) : AuthRepository {
-
-    private val prefs by lazy {
-        context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-    }
 
     private fun saveSession(user: ApiUserResponse, token: String, refreshToken: String? = null) {
         prefs.edit()
@@ -70,7 +66,8 @@ class ApiAuthRepository @Inject constructor(
         } catch (e: HttpException) {
             val body = e.response()?.errorBody()?.string() ?: e.message()
             Log.e("MongleApi", "❌ HTTP ${e.code()}")
-            throw Exception(parseServerMessage(body))
+            // MG-102 cause 로 HttpException 보존 → RootViewModel 등이 e.cause.code() 로 401 분기 가능.
+            throw Exception(parseServerMessage(body), e)
         } catch (e: Exception) {
             Log.e("MongleApi", "❌ API 호출 실패: ${e.message}", e)
             throw e

--- a/app/src/main/java/com/mongle/android/data/remote/AuthInterceptor.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/AuthInterceptor.kt
@@ -1,25 +1,23 @@
 package com.mongle.android.data.remote
 
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
+import android.content.SharedPreferences
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.util.Locale
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
-private const val PREF_NAME = "mongle_auth"
 private const val KEY_TOKEN = "auth_token"
 
 @Singleton
 class AuthInterceptor @Inject constructor(
-    @ApplicationContext private val context: Context
+    // MG-95 EncryptedSharedPreferences 인스턴스를 SecurityModule 에서 주입.
+    @Named("auth") private val authPrefs: SharedPreferences
 ) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val token = context
-            .getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-            .getString(KEY_TOKEN, null)
+        val token = authPrefs.getString(KEY_TOKEN, null)
 
         val lang = when (Locale.getDefault().language) {
             "ko" -> "ko"

--- a/app/src/main/java/com/mongle/android/data/remote/TokenAuthenticator.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/TokenAuthenticator.kt
@@ -1,9 +1,8 @@
 package com.mongle.android.data.remote
 import com.ycompany.Monggle.BuildConfig
 
-import android.content.Context
+import android.content.SharedPreferences
 import com.squareup.moshi.Moshi
-import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.Authenticator
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -14,9 +13,9 @@ import okhttp3.Route
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
-private const val AUTH_PREF_NAME = "mongle_auth"
 private const val AUTH_KEY_TOKEN = "auth_token"
 private const val AUTH_KEY_REFRESH_TOKEN = "refresh_token"
 
@@ -27,22 +26,25 @@ private const val AUTH_KEY_REFRESH_TOKEN = "refresh_token"
  */
 @Singleton
 class TokenAuthenticator @Inject constructor(
-    @ApplicationContext private val context: Context,
+    // MG-95 EncryptedSharedPreferences 인스턴스를 SecurityModule 에서 주입.
+    @Named("auth") private val prefs: SharedPreferences,
     private val moshi: Moshi,
     private val sessionExpiredNotifier: SessionExpiredNotifier
 ) : Authenticator {
 
     private val baseUrl = BuildConfig.BASE_URL
 
-    private val prefs by lazy {
-        context.getSharedPreferences(AUTH_PREF_NAME, Context.MODE_PRIVATE)
-    }
-
     // Authenticator 전용 clean client (인터셉터/authenticator 없음, 무한루프 방지)
     private val refreshClient = OkHttpClient.Builder().build()
 
     private val refreshAdapter by lazy {
         moshi.adapter(TokenRefreshResponse::class.java)
+    }
+
+    // MG-93 raw string interpolation 으로 JSON 빌드 시 refresh_token 에 ", \, 제어문자 포함되면
+    // JSON 깨져 서버가 invalid token 으로 판단 → 무고한 강제 로그아웃. Moshi 직렬화로 안전 처리.
+    private val refreshRequestAdapter by lazy {
+        moshi.adapter(RefreshTokenRequest::class.java)
     }
 
     // iOS MG-35 패리티 — 동시 401 발생 시 refresh 가 한 번만 일어나도록 보호한다.
@@ -86,7 +88,7 @@ class TokenAuthenticator @Inject constructor(
 
     private fun performRefresh(refreshToken: String, response: Response): Request? {
         return try {
-            val body = """{"refresh_token":"$refreshToken"}"""
+            val body = refreshRequestAdapter.toJson(RefreshTokenRequest(refresh_token = refreshToken))
                 .toRequestBody("application/json".toMediaType())
 
             val refreshRequest = Request.Builder()

--- a/app/src/main/java/com/mongle/android/di/NetworkModule.kt
+++ b/app/src/main/java/com/mongle/android/di/NetworkModule.kt
@@ -14,6 +14,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -34,11 +35,23 @@ object NetworkModule {
         authInterceptor: AuthInterceptor,
         tokenAuthenticator: TokenAuthenticator
     ): OkHttpClient = OkHttpClient.Builder()
+        // MG-94 약전계/핸드오프/서버 SIGTERM 직전 body stream hang 시 코루틴 무한 대기 방지.
+        // OkHttp 기본 callTimeout 은 0(무제한) — 명시 상한 필요.
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(20, TimeUnit.SECONDS)
+        .writeTimeout(20, TimeUnit.SECONDS)
+        .callTimeout(30, TimeUnit.SECONDS)
+        .retryOnConnectionFailure(true)
         .addInterceptor(authInterceptor)
         .authenticator(tokenAuthenticator)
         .addInterceptor(
+            // MG-105 BODY 레벨은 EmailLoginBody/AuthResponse 평문 logcat 노출.
+            // HEADERS 레벨로 낮추고 Authorization/Cookie redact.
             HttpLoggingInterceptor().apply {
-                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY else HttpLoggingInterceptor.Level.NONE
+                level = if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.HEADERS
+                else HttpLoggingInterceptor.Level.NONE
+                redactHeader("Authorization")
+                redactHeader("Cookie")
             }
         )
         .build()

--- a/app/src/main/java/com/mongle/android/di/SecurityModule.kt
+++ b/app/src/main/java/com/mongle/android/di/SecurityModule.kt
@@ -1,0 +1,83 @@
+package com.mongle.android.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+
+/**
+ * MG-95 토큰/PII 평문 SharedPreferences 저장 제거.
+ *
+ * iOS 가 Keychain 을 사용하는 것과 동등하게 EncryptedSharedPreferences(AES256) 적용.
+ * 분실/루팅 단말에서 평문 추출이 불가능해지며, refresh_token 유출 위험을 차단한다.
+ *
+ * 마이그레이션:
+ * - 첫 호출 시 기존 `mongle_auth` 평문 prefs 의 값을 `mongle_auth_secure` 로 복사 후 평문 prefs.clear().
+ * - 키스토어 손상 등으로 EncryptedSharedPreferences 생성이 실패한 경우 평문 prefs 로 fallback (사용성 우선).
+ *   이 경우 다음 가용 시점에 다시 시도하도록 마이그레이션 sentinel 도 둠.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object SecurityModule {
+
+    private const val LEGACY_AUTH_PREFS = "mongle_auth"
+    private const val SECURE_AUTH_PREFS = "mongle_auth_secure"
+    private const val MIGRATION_SENTINEL_KEY = "secure_migration_done"
+
+    @Provides
+    @Singleton
+    @Named("auth")
+    fun provideAuthPrefs(@ApplicationContext context: Context): SharedPreferences {
+        val secure = createSecurePrefs(context) ?: run {
+            Log.e("SecurityModule", "EncryptedSharedPreferences 생성 실패 — 평문 prefs 로 fallback")
+            return context.getSharedPreferences(LEGACY_AUTH_PREFS, Context.MODE_PRIVATE)
+        }
+        migrateLegacyIfNeeded(context, secure)
+        return secure
+    }
+
+    private fun createSecurePrefs(context: Context): SharedPreferences? = runCatching {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+        EncryptedSharedPreferences.create(
+            context,
+            SECURE_AUTH_PREFS,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }.getOrNull()
+
+    private fun migrateLegacyIfNeeded(context: Context, secure: SharedPreferences) {
+        if (secure.getBoolean(MIGRATION_SENTINEL_KEY, false)) return
+        val legacy = context.getSharedPreferences(LEGACY_AUTH_PREFS, Context.MODE_PRIVATE)
+        if (legacy.all.isEmpty()) {
+            secure.edit().putBoolean(MIGRATION_SENTINEL_KEY, true).apply()
+            return
+        }
+        val editor = secure.edit()
+        for ((k, v) in legacy.all) {
+            when (v) {
+                is String -> editor.putString(k, v)
+                is Boolean -> editor.putBoolean(k, v)
+                is Int -> editor.putInt(k, v)
+                is Long -> editor.putLong(k, v)
+                is Float -> editor.putFloat(k, v)
+                else -> Log.w("SecurityModule", "마이그레이션 스킵 — 미지원 타입 key=$k")
+            }
+        }
+        editor.putBoolean(MIGRATION_SENTINEL_KEY, true).apply()
+        // 평문 prefs 의 토큰/PII 는 더 이상 신뢰 저장소가 아니므로 즉시 폐기.
+        legacy.edit().clear().apply()
+        Log.i("SecurityModule", "Legacy mongle_auth → mongle_auth_secure 마이그레이션 완료")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ moshi = "1.15.1"
 googleMobileAds = "23.3.0"
 userMessagingPlatform = "3.1.0"
 firebaseBom = "33.1.0"
+securityCrypto = "1.1.0-alpha06"
 
 [libraries]
 # Core
@@ -75,6 +76,9 @@ google-user-messaging-platform = { group = "com.google.android.ump", name = "use
 # Firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging-ktx" }
+
+# Jetpack Security — EncryptedSharedPreferences (MG-95)
+androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 # Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
- MG-93: TokenAuthenticator refresh JSON raw string interpolation 제거 → Moshi RefreshTokenRequest adapter 직렬화로 변경. refresh_token 에 ", \, 제어문자 포함 시 JSON 깨져 강제 로그아웃 되는 회귀 차단.

- MG-94: OkHttpClient connect/read/write/callTimeout 명시 (15/20/20/30s)
  + retryOnConnectionFailure(true). 약전계/핸드오프 시 무한 hang 방지.

- MG-95: EncryptedSharedPreferences 도입 (AES256-GCM/SIV)
  - SecurityModule.kt 신규 — @Named("auth") SharedPreferences 제공
  - AuthInterceptor / TokenAuthenticator / ApiAuthRepository 모두 동일 인스턴스 주입
  - 마이그레이션 1회: 평문 mongle_auth → mongle_auth_secure 복사 후 평문 prefs.clear()
  - 키스토어 손상 시 평문 prefs fallback (사용성 우선)
  - 분실/루팅 단말에서 토큰 평문 추출 차단.

- MG-105: HttpLoggingInterceptor.Level.BODY → HEADERS (DEBUG 시), Release 는 NONE 유지. redactHeader("Authorization") / "Cookie" 추가 — 토큰/비밀번호 logcat 평문 노출 위험 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)