### PR TITLE
fix(MG-97,98): Compose 라이프사이클 안정화

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/consent/ConsentViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/consent/ConsentViewModel.kt
@@ -7,6 +7,7 @@ import com.mongle.android.domain.model.LegalDocType
 import com.mongle.android.domain.model.LegalVersions
 import com.mongle.android.domain.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -46,7 +47,11 @@ class ConsentViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(ConsentUiState())
     val uiState: StateFlow<ConsentUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<ConsentEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지.
+    private val _events = MutableSharedFlow<ConsentEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<ConsentEvent> = _events.asSharedFlow()
 
     fun setContext(

--- a/app/src/main/java/com/mongle/android/ui/emailauth/EmailLoginViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/emailauth/EmailLoginViewModel.kt
@@ -7,6 +7,7 @@ import com.ycompany.Monggle.R
 import com.mongle.android.domain.model.SocialLoginResult
 import com.mongle.android.domain.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -49,7 +50,11 @@ class EmailLoginViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(EmailLoginUiState())
     val uiState: StateFlow<EmailLoginUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<EmailLoginEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지.
+    private val _events = MutableSharedFlow<EmailLoginEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<EmailLoginEvent> = _events.asSharedFlow()
 
     fun onEmailChanged(value: String) {

--- a/app/src/main/java/com/mongle/android/ui/emailauth/EmailSignupViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/emailauth/EmailSignupViewModel.kt
@@ -12,6 +12,7 @@ import com.mongle.android.domain.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -77,7 +78,11 @@ class EmailSignupViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(EmailSignupUiState())
     val uiState: StateFlow<EmailSignupUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<EmailSignupEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지.
+    private val _events = MutableSharedFlow<EmailSignupEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<EmailSignupEvent> = _events.asSharedFlow()
 
     private var resendTimerJob: Job? = null

--- a/app/src/main/java/com/mongle/android/ui/history/HistoryScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/history/HistoryScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/com/mongle/android/ui/history/HistoryViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/history/HistoryViewModel.kt
@@ -10,6 +10,7 @@ import com.mongle.android.domain.repository.AuthRepository
 import com.mongle.android.domain.repository.MongleRepository
 import com.mongle.android.domain.repository.QuestionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -76,7 +77,11 @@ class HistoryViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(HistoryUiState())
     val uiState: StateFlow<HistoryUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<HistoryEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지.
+    private val _events = MutableSharedFlow<HistoryEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<HistoryEvent> = _events.asSharedFlow()
 
     init {

--- a/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import com.mongle.android.domain.repository.QuestionRepository
 import com.mongle.android.domain.repository.TreeRepository
 import com.mongle.android.util.AdManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -76,11 +77,18 @@ class HomeViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<HomeEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지.
+    private val _events = MutableSharedFlow<HomeEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<HomeEvent> = _events.asSharedFlow()
 
     /** 질문 넘기기 성공 시 남은 하트 수를 상위로 전파 */
-    private val _skipEvents = MutableSharedFlow<Int>()
+    private val _skipEvents = MutableSharedFlow<Int>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val skipEvents: SharedFlow<Int> = _skipEvents.asSharedFlow()
 
     fun initialize(

--- a/app/src/main/java/com/mongle/android/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/login/LoginViewModel.kt
@@ -11,6 +11,7 @@ import com.mongle.android.domain.model.SocialProviderType
 import com.mongle.android.domain.model.User
 import com.mongle.android.domain.repository.AuthRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -48,7 +49,11 @@ class LoginViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<LoginEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지 (회전·메모리 부족).
+    private val _events = MutableSharedFlow<LoginEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<LoginEvent> = _events.asSharedFlow()
 
     fun loginWithSocial(credential: SocialLoginCredential) {

--- a/app/src/main/java/com/mongle/android/ui/main/MainTabScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/main/MainTabScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -56,7 +57,9 @@ fun MainTabScreen(
     answerSubmittedCount: Int = 0,
     adManager: AdManager? = null
 ) {
-    var selectedTab by remember { mutableStateOf(MainTab.HOME) }
+    // MG-98 회전·다크모드·메모리 부족 시 Activity 재생성 후에도 탭 유지.
+    // enum 은 기본 Saver(autoSaver) 가 처리.
+    var selectedTab by rememberSaveable { mutableStateOf(MainTab.HOME) }
     val homeViewModel: HomeViewModel = hiltViewModel()
     val historyViewModel: HistoryViewModel = hiltViewModel()
 

--- a/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
+++ b/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,17 +62,20 @@ fun MongleNavHost(
     adManager: AdManager? = null
 ) {
     val uiState by rootViewModel.uiState.collectAsState()
+    // MG-98 회전·다크모드 후에도 오버레이/토스트 상태 유지.
+    // Question?/User? 복합 객체는 Parcelable Saver 미정의로 rememberSaveable 자동 처리 불가 →
+    // 회전 시 닫힘(현재 동작) 유지. boolean/int 만 saveable 처리.
     var showQuestionDetail by remember { mutableStateOf<Question?>(null) }
-    var showNotifications by remember { mutableStateOf(false) }
+    var showNotifications by rememberSaveable { mutableStateOf(false) }
     var showNudgeTarget by remember { mutableStateOf<User?>(null) }
-    var showWriteQuestion by remember { mutableStateOf(false) }
-    var showGroupSelect by remember { mutableStateOf(false) }
-    var groupLeftToast by remember { mutableStateOf(false) }
-    var showAnswerSubmittedToast by remember { mutableStateOf(false) }
-    var showSkipToast by remember { mutableStateOf(false) }
-    var showWriteQuestionToast by remember { mutableStateOf(false) }
-    var showHeartPopup by remember { mutableStateOf(false) }
-    var answerSubmittedCount by remember { mutableIntStateOf(0) }
+    var showWriteQuestion by rememberSaveable { mutableStateOf(false) }
+    var showGroupSelect by rememberSaveable { mutableStateOf(false) }
+    var groupLeftToast by rememberSaveable { mutableStateOf(false) }
+    var showAnswerSubmittedToast by rememberSaveable { mutableStateOf(false) }
+    var showSkipToast by rememberSaveable { mutableStateOf(false) }
+    var showWriteQuestionToast by rememberSaveable { mutableStateOf(false) }
+    var showHeartPopup by rememberSaveable { mutableStateOf(false) }
+    var answerSubmittedCount by rememberSaveable { mutableIntStateOf(0) }
 
     // 답변 완료 토스트 3초 후 자동 닫기
     LaunchedEffect(showAnswerSubmittedToast) {

--- a/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
@@ -11,6 +11,7 @@ import com.mongle.android.domain.model.User
 import com.mongle.android.domain.repository.AnswerRepository
 import com.mongle.android.util.AdManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -65,7 +66,11 @@ class QuestionDetailViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(QuestionDetailUiState())
     val uiState: StateFlow<QuestionDetailUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<QuestionDetailEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지.
+    private val _events = MutableSharedFlow<QuestionDetailEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<QuestionDetailEvent> = _events.asSharedFlow()
 
     private var initialized = false

--- a/app/src/main/java/com/mongle/android/ui/question/WriteQuestionViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/WriteQuestionViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.mongle.android.domain.model.Question
 import com.mongle.android.domain.repository.QuestionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -36,7 +37,11 @@ class WriteQuestionViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(WriteQuestionUiState())
     val uiState: StateFlow<WriteQuestionUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<WriteQuestionEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지.
+    private val _events = MutableSharedFlow<WriteQuestionEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<WriteQuestionEvent> = _events.asSharedFlow()
 
     fun onQuestionTextChanged(text: String) {

--- a/app/src/main/java/com/mongle/android/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.mongle.android.ui.login.unlinkKakao
 import com.mongle.android.util.ConsentManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -90,7 +91,11 @@ class SettingsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
-    private val _events = MutableSharedFlow<SettingsEvent>()
+    // MG-97 collect 단절 사이 이벤트 유실 방지.
+    private val _events = MutableSharedFlow<SettingsEvent>(
+        extraBufferCapacity = 16,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     val events: SharedFlow<SettingsEvent> = _events.asSharedFlow()
 
     fun initialize(user: User?, providerType: SocialProviderType?) {


### PR DESCRIPTION
- MG-97: 9개 ViewModel SharedFlow 이벤트 손실 차단 default config(replay=0, buffer=0, SUSPEND) 에서 회전·메모리 부족 시 collect 단절 사이 emit 된 이벤트가 호출 측 코루틴 cancel 과 함께 사라지는 회귀 (로그인 직후 미진입, 답변 제출 후 토스트 안 뜸 등 비결정적) 차단.

  적용 ViewModel: Login, EmailLogin, EmailSignup, Consent, Home(events+skipEvents), QuestionDetail, WriteQuestion, Settings, History.

  패턴: extraBufferCapacity = 16, onBufferOverflow = BufferOverflow.DROP_OLDEST. SessionExpiredNotifier 는 이미 buffer=1 — 변경 없음.

- MG-98: rememberSaveable 적용 — 회전·다크모드·시스템 폰트 변경 후에도 상태 유지
  - MainTabScreen.selectedTab (enum) — autoSaver 처리
  - MongleNavHost 의 boolean/Int 상태 9개 (showNotifications, showWriteQuestion 등)
  - showQuestionDetail (Question?) / showNudgeTarget (User?) 는 Parcelable Saver 미정의로 remember 유지 — 회전 시 닫힘 (후속 작업으로 @Parcelize 또는 ID 보관 패턴 적용 가능)

- HistoryScreen.kt: remember import 누락 수정 (MG-97 빌드 통과를 위해 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)