### PR TITLE
fix(MG-99,102,104): Root/Deep link 보안 + 401 판정 + silent fallback

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,13 +41,13 @@
                 <data android:scheme="monggle" android:host="apple-callback" />
             </intent-filter>
 
-            <!-- Android App Links -->
+            <!-- Android App Links — MG-99 http scheme 단독 라인 제거.
+                 verified host(monggle.app)에 한정해서 매칭. -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" android:host="monggle.app" android:pathPrefix="/join" />
-                <data android:scheme="http" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/mongle/android/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/login/LoginScreen.kt
@@ -108,7 +108,8 @@ fun LoginScreen(
         val uri = pendingAppleCallbackUri ?: return@LaunchedEffect
         onAppleCallbackConsumed()
         try {
-            val credential = handleAppleCallback(uri)
+            // MG-99 handleAppleCallback 가 state 일치 검증을 위해 context 를 받음.
+            val credential = handleAppleCallback(context, uri)
             Log.d("LoginScreen", "Apple 토큰 파싱 성공 → 서버 로그인 요청")
             viewModel.loginWithSocial(credential)
         } catch (e: Exception) {

--- a/app/src/main/java/com/mongle/android/ui/login/SocialLoginHelper.kt
+++ b/app/src/main/java/com/mongle/android/ui/login/SocialLoginHelper.kt
@@ -151,17 +151,28 @@ suspend fun revokeGoogleAccess(context: Context): Unit = suspendCancellableCorou
 // ── 애플 ────────────────────────────────────────────
 // Apple Sign-In on Android: Custom Tab → Apple OAuth → 서버 콜백 → 앱 딥링크
 
+private const val APPLE_OAUTH_PREFS = "apple_oauth"
+private const val APPLE_OAUTH_STATE_KEY = "state"
+
 /**
  * Apple OAuth URL을 빌드하여 Custom Tab으로 실행합니다.
  * 서버가 form_post를 받아 monggle://apple-callback?id_token=...&code=... 로 리다이렉트합니다.
+ *
+ * MG-99 CSRF 방어 — 매 요청마다 nonce 를 생성해 SharedPreferences 에 저장하고
+ * state 파라미터로 전송. 콜백 시점에 동일한 state 가 돌아왔는지 검증한다.
  */
 fun launchAppleSignIn(context: Context) {
+    val state = java.util.UUID.randomUUID().toString()
+    context.getSharedPreferences(APPLE_OAUTH_PREFS, Context.MODE_PRIVATE)
+        .edit().putString(APPLE_OAUTH_STATE_KEY, state).apply()
+
     val appleAuthUrl = Uri.parse("https://appleid.apple.com/auth/authorize").buildUpon()
         .appendQueryParameter("client_id", APPLE_CLIENT_ID)
         .appendQueryParameter("redirect_uri", APPLE_REDIRECT_URI)
         .appendQueryParameter("response_type", "code id_token")
         .appendQueryParameter("scope", "name email")
         .appendQueryParameter("response_mode", "form_post")
+        .appendQueryParameter("state", state)
         .build()
 
     Log.d("AppleLogin", "Apple OAuth URL: $appleAuthUrl")
@@ -172,9 +183,20 @@ fun launchAppleSignIn(context: Context) {
 
 /**
  * Apple 콜백 딥링크 URI에서 credential을 파싱합니다.
- * URI 형식: monggle://apple-callback?id_token=...&code=...&name=...&email=...
+ * URI 형식: monggle://apple-callback?id_token=...&code=...&state=...&name=...&email=...
+ *
+ * MG-99 state 일치 검증 — launchAppleSignIn 에서 저장한 state 와 다르면 CSRF 의심으로 거부.
  */
-fun handleAppleCallback(uri: Uri): AppleLoginCredential {
+fun handleAppleCallback(context: Context, uri: Uri): AppleLoginCredential {
+    val prefs = context.getSharedPreferences(APPLE_OAUTH_PREFS, Context.MODE_PRIVATE)
+    val expectedState = prefs.getString(APPLE_OAUTH_STATE_KEY, null)
+    val receivedState = uri.getQueryParameter("state")
+    // 검증 후 state 는 1회용이므로 즉시 폐기 (성공/실패 무관).
+    prefs.edit().remove(APPLE_OAUTH_STATE_KEY).apply()
+    if (expectedState == null || receivedState == null || expectedState != receivedState) {
+        throw Exception("Apple 로그인 실패: state 불일치 (CSRF 의심)")
+    }
+
     val idToken = uri.getQueryParameter("id_token")
         ?: throw Exception("Apple 로그인 실패: identity_token이 없습니다.")
     val code = uri.getQueryParameter("code")

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -19,6 +19,7 @@ import com.mongle.android.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
+import retrofit2.HttpException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -138,11 +139,13 @@ class RootViewModel @Inject constructor(
                 familiesResult.onSuccess { allFamilies ->
                     _uiState.update { it.copy(appState = AppState.GroupSelection, allFamilies = allFamilies) }
                 }.onFailure { e ->
-                    val msg = e.message ?: ""
-                    val isAuthError = msg.contains("401") ||
-                        msg.contains("token", ignoreCase = true) ||
-                        msg.contains("unauthorized", ignoreCase = true) ||
-                        msg.contains("invalid", ignoreCase = true)
+                    // MG-102 에러 메시지 substring 매칭은 i18n 한국어 응답("토큰", "유효하지 않")에서 401
+                    // 누락, 정상 도메인 에러 메시지("invalid name")에서 오탐(잘못된 강제 로그아웃)을 일으켰음.
+                    // HttpException.code() 로 정확히 401 만 인증 에러로 분기.
+                    // (cause 체인까지 들여다보는 이유는 safeCall 류 wrapper 가 HttpException 을 cause 로
+                    //  보존할 수도, 그대로 던질 수도 있어 둘 다 커버하기 위함)
+                    val isAuthError = (e as? HttpException)?.code() == 401 ||
+                        (e.cause as? HttpException)?.code() == 401
                     if (isAuthError) {
                         // 토큰 만료/무효 → 세션 초기화 후 로그인 화면
                         runCatching { authRepository.logout() }
@@ -164,17 +167,24 @@ class RootViewModel @Inject constructor(
         loadHomeDataJob?.cancel()
         loadHomeDataJob = viewModelScope.launch {
             try {
-                val familyResult = runCatching { mongleRepository.getMyFamily() }.getOrNull()
+                // MG-104 네트워크 에러를 빈 데이터로 silent fallback 하면 사용자가 "데이터 없음"으로 오해.
+                // 호출별 실패를 추적해 마지막에 errorMessage 동반 노출 (fallback 동작 자체는 유지 — 점진적 디그라데이션).
+                var lastNetworkError: Throwable? = null
+                val familyResult = runCatching { mongleRepository.getMyFamily() }
+                    .onFailure { lastNetworkError = it }.getOrNull()
                 val family = familyResult?.first
                 val members = familyResult?.second ?: emptyList()
-                var question = runCatching { questionRepository.getTodayQuestion() }.getOrNull()
+                var question = runCatching { questionRepository.getTodayQuestion() }
+                    .onFailure { lastNetworkError = it }.getOrNull()
                 val tree = runCatching { treeRepository.getMyTreeProgress() }.getOrElse { TreeProgress() }
 
-                val allFamilies = runCatching { mongleRepository.getMyFamilies() }.getOrElse { emptyList() }
+                val allFamilies = runCatching { mongleRepository.getMyFamilies() }
+                    .onFailure { lastNetworkError = it }.getOrElse { emptyList() }
 
                 // 오늘의 질문을 찾지 못한 경우 히스토리에서 가장 최근 질문을 fallback으로 사용
                 if (question == null) {
-                    val history = runCatching { questionRepository.getDailyHistory(page = 1, limit = 5) }.getOrElse { emptyList() }
+                    val history = runCatching { questionRepository.getDailyHistory(page = 1, limit = 5) }
+                        .onFailure { lastNetworkError = it }.getOrElse { emptyList() }
                     val recent = history.firstOrNull()
                     if (recent != null) {
                         question = recent.question.copy(
@@ -210,6 +220,9 @@ class RootViewModel @Inject constructor(
                         // refreshedUser 우선 — 서버 grantDailyHeart 응답이 가장 최신.
                         // members 의 me 는 hearts 등 일부 필드만 동기화되며 heartGrantedToday 는 미포함.
                         val syncedUser = refreshedUser ?: serverMe ?: it.currentUser
+                        // MG-104 family 는 위 if 로 이미 보장됨 — question 만 비고 네트워크 에러가 있었으면
+                        // "데이터 없음" 이 아니라 네트워크 안내를 띄움.
+                        val degraded = question == null && lastNetworkError != null
                         it.copy(
                             appState = AppState.Authenticated,
                             todayQuestion = question,
@@ -222,7 +235,8 @@ class RootViewModel @Inject constructor(
                             hasSkippedToday = question?.hasMySkipped ?: false,
                             // set-only — heartGrantedToday=false 응답일 땐 기존 값 유지(이미 본 팝업 재트리거 방지)
                             dailyHeartGranted = if (heartGrantedToday) 1 else it.dailyHeartGranted,
-                            currentUser = syncedUser
+                            currentUser = syncedUser,
+                            errorMessage = if (degraded) lastNetworkError?.message else it.errorMessage
                         )
                     }
                 }
@@ -262,9 +276,15 @@ class RootViewModel @Inject constructor(
             uri.host == "monggle.app" && uri.pathSegments.size >= 2 && uri.pathSegments[0] == "join" -> uri.pathSegments[1].uppercase()
             else -> null
         }
-        if (code != null) {
+        // MG-99 외부 인텐트가 임의 문자열 prefill 하지 못하도록 형식 검증.
+        // 서버 발급 invite code 는 영숫자 6자리. 검증 실패 시 무시.
+        if (code != null && INVITE_CODE_REGEX.matches(code)) {
             _uiState.update { it.copy(pendingInviteCode = code) }
         }
+    }
+
+    private companion object {
+        private val INVITE_CODE_REGEX = Regex("^[A-Z0-9]{6}$")
     }
 
     fun clearPendingAppleCallback() {


### PR DESCRIPTION
- MG-99: Deep link 검증 + Apple OAuth state nonce
  - AndroidManifest: <data android:scheme="http" /> 단독 라인 제거. https + verified host(monggle.app) 만 매칭하도록 정리.
  - RootViewModel.handleDeepLink: invite code regex `^[A-Z0-9]{6}$` 검증. 악성 앱이 임의 문자열로 join 화면 prefill 차단.
  - SocialLoginHelper: Apple OAuth 시작 시 UUID state 생성 → SharedPreferences 저장. handleAppleCallback(context, uri) 가 받은 state 와 비교 → 불일치 시 거부 (CSRF 방어). state 는 1회용 (성공/실패 무관 즉시 폐기).
  - LoginScreen: handleAppleCallback 새 시그니처 적용.

- MG-102: 401 판정을 메시지 substring 매칭에서 HttpException.code() 로 변경 서버 i18n 한국어 응답("토큰", "유효하지 않")에서 401 누락, "invalid name" 같은 도메인 에러에서 오탐(잘못된 강제 로그아웃) 케이스 모두 차단. (e as? HttpException)?.code() == 401 || (e.cause as? HttpException)?.code() == 401 cause 까지 확인하는 이유: safeCall wrapper 가 HttpException 을 cause 로 보존 (PR1 의 ApiAuthRepository.safeCall 변경과 함께 동작).

- MG-104: loadHomeData silent fallback 보완 — errorMessage 동반 노출 4개 호출 (getMyFamily/getTodayQuestion/getMyFamilies/getDailyHistory) 의 실패를 lastNetworkError 로 추적. question 이 비고 네트워크 에러가 있었으면 "데이터 없음" 이 아니라 errorMessage 표시 (fallback 동작 자체는 유지 — 점진적 디그라데이션).

🤖 Generated with [Claude Code](https://claude.com/claude-code)