### PR TITLE
fix(MG-100,101): 날짜 파싱 thread-safety + UTC 명시

### DIFF
--- a/app/src/main/java/com/mongle/android/data/remote/ApiQuestionRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ApiQuestionRepository.kt
@@ -140,9 +140,16 @@ class ApiQuestionRepository @Inject constructor(
         }
     }
 
+    // MG-100 SimpleDateFormat 은 thread-unsafe — ThreadLocal 로 인스턴스 격리.
+    // TimeZone 을 default 로 두면 KST 자정 직후 답변이 1일 어긋남 → UTC 명시.
+    private val dateOnlyFormat = ThreadLocal.withInitial {
+        java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.US).apply {
+            timeZone = java.util.TimeZone.getTimeZone("UTC")
+            isLenient = false
+        }
+    }
+
     private fun parseDate(dateStr: String): java.util.Date {
-        return runCatching {
-            java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault()).parse(dateStr) ?: Date()
-        }.getOrElse { Date() }
+        return runCatching { dateOnlyFormat.get()!!.parse(dateStr) }.getOrNull() ?: Date()
     }
 }

--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
@@ -458,21 +458,29 @@ private fun notificationTypeStyle(type: String): NotifStyle = when (type.lowerca
 // 서버가 보내는 createdAt은 UTC 기준 ISO 8601 문자열.
 // 'Z'는 SimpleDateFormat에서 리터럴로 취급되므로 반드시 TimeZone을 UTC로 명시해야
 // KST(+9) 환경에서 9시간 어긋난 값을 피할 수 있다.
-private val isoFormatZ = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.getDefault()).apply {
-    timeZone = java.util.TimeZone.getTimeZone("UTC")
+// MG-101 SimpleDateFormat 은 thread-unsafe — LazyColumn prefetch / 향후 백그라운드 호출 시
+// ParseException/silent corruption 위험. ThreadLocal 로 인스턴스 격리.
+private val isoFormatZ = ThreadLocal.withInitial {
+    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+        timeZone = java.util.TimeZone.getTimeZone("UTC")
+    }
 }
-private val isoFormatMillisZ = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault()).apply {
-    timeZone = java.util.TimeZone.getTimeZone("UTC")
+private val isoFormatMillisZ = ThreadLocal.withInitial {
+    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+        timeZone = java.util.TimeZone.getTimeZone("UTC")
+    }
 }
 // 타임존 표기가 없는 경우도 UTC로 해석 (서버가 항상 UTC를 내려준다고 가정)
-private val isoFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.getDefault()).apply {
-    timeZone = java.util.TimeZone.getTimeZone("UTC")
+private val isoFormat = ThreadLocal.withInitial {
+    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {
+        timeZone = java.util.TimeZone.getTimeZone("UTC")
+    }
 }
 
 private fun timeAgo(createdAt: String, res: Resources): String {
-    val date = runCatching { isoFormatMillisZ.parse(createdAt) }.getOrNull()
-        ?: runCatching { isoFormatZ.parse(createdAt) }.getOrNull()
-        ?: runCatching { isoFormat.parse(createdAt) }.getOrNull()
+    val date = runCatching { isoFormatMillisZ.get()!!.parse(createdAt) }.getOrNull()
+        ?: runCatching { isoFormatZ.get()!!.parse(createdAt) }.getOrNull()
+        ?: runCatching { isoFormat.get()!!.parse(createdAt) }.getOrNull()
         ?: return ""
     val diffMs = Date().time - date.time
     val diffMin = TimeUnit.MILLISECONDS.toMinutes(diffMs)


### PR DESCRIPTION
- MG-100: ApiQuestionRepository.parseDate UTC TimeZone 명시 + ThreadLocal 서버가 내려준 yyyy-MM-dd 를 default TimeZone(KST 등)으로 파싱하면 UTC 자정 기준 응답 시 KST 와 9시간 차이로 자정 직후 답변이 1일 어긋남 (HistoryViewModel 의 정규화 millis 키와 캘린더 셀 키 불일치). ThreadLocal<SimpleDateFormat> 으로 인스턴스 격리(thread-safe) + UTC 강제.

- MG-101: NotificationScreen SimpleDateFormat ThreadLocal 격리 isoFormatZ / isoFormatMillisZ / isoFormat 가 파일 top-level 단일 인스턴스 → thread-unsafe (LazyColumn prefetch / 향후 백그라운드 호출 시 ParseException 위험). ThreadLocal.withInitial { ... } 로 감싸서 인스턴스 격리. Locale 도 getDefault() → US 로 변경 (포맷 문자열 안정성).

🤖 Generated with [Claude Code](https://claude.com/claude-code)