### PR TITLE
fix(MG-96,103): FCM 알림 ID 충돌 + LazyColumn key 누락

### DIFF
--- a/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
+++ b/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
@@ -16,6 +16,12 @@ import com.ycompany.Monggle.R
 
 class MongleFcmService : FirebaseMessagingService() {
 
+    companion object {
+        // MG-96 currentTimeMillis().toInt() 는 49.7일 wrap-around + 동일 millisecond 충돌 가능.
+        // AtomicInteger 단조 증가로 알림 ID 충돌을 원천 차단.
+        private val notificationIdSeq = java.util.concurrent.atomic.AtomicInteger(1000)
+    }
+
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         // 토큰 저장 실패가 silent 하게 묻히지 않도록 try-catch + 로그.
@@ -71,6 +77,6 @@ class MongleFcmService : FirebaseMessagingService() {
             .setContentIntent(pending)
             .build()
 
-        manager.notify(System.currentTimeMillis().toInt(), notification)
+        manager.notify(notificationIdSeq.incrementAndGet(), notification)
     }
 }

--- a/app/src/main/java/com/mongle/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/settings/SettingsScreen.kt
@@ -681,7 +681,9 @@ private fun TransferAdminScreen(
                 MongleMonggleGreenLight, MongleMonggleYellow, MongleMongglePink, MongleMonggleBlue, MongleMonggleOrange
             )
             LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
-                itemsIndexed(uiState.transferCandidates) { index, member ->
+                // MG-103 멤버 ID 를 key 로 지정해 LazyColumn 이 인덱스 대신 ID 로 row 식별.
+                // 멤버가 그룹을 떠나도 selection/애니메이션이 잘못된 row 에 결합되지 않음.
+                itemsIndexed(uiState.transferCandidates, key = { _, m -> m.id }) { index, member ->
                     val selected = uiState.selectedTransferMemberId == member.id
                     val bgColor = if (selected) MonglePrimaryLight else Color.White
                     val borderColor = if (selected) MonglePrimary else Color(0xFFE0D8D0)


### PR DESCRIPTION
- MG-96: FCM 알림 ID currentTimeMillis().toInt() → AtomicInteger 시퀀스 Long → Int 트렁케이션은 49.7일 wrap-around 위험 + 동일 millisecond 에 도착하는 동시 푸시(가족 다인 동시 답변·재촉) 가 같은 ID 로 NotificationManager 에 들어가 기존 알림 덮어쓰기 → 사용자 알림 누락. AtomicInteger 단조 증가로 원천 차단.

- MG-103: SettingsScreen 위임 시트 LazyColumn key 추가 itemsIndexed(transferCandidates) { ... } 키 미지정 → 멤버 추가/제거 시 LazyColumn 이 인덱스로 식별 → selection/애니메이션 결합. key = { _, m -> m.id } 추가로 ID 기반 식별.

🤖 Generated with [Claude Code](https://claude.com/claude-code)