### PR TITLE
fix(MG-106): OS app icon badge number + FCM auth-flow banner guard

### DIFF
--- a/app/src/main/java/com/mongle/android/data/local/UnreadBadgeStore.kt
+++ b/app/src/main/java/com/mongle/android/data/local/UnreadBadgeStore.kt
@@ -1,0 +1,44 @@
+package com.mongle.android.data.local
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val PREFS_NAME = "mongle_badge"
+private const val KEY_UNREAD = "unread_count"
+
+/**
+ * iOS MG-39 패리티 — 앱 아이콘 배지의 미읽음 수 source-of-truth.
+ *
+ * Android 런처는 NotificationCompat.Builder.setNumber(n) 호출이 있어야 아이콘 위에
+ * 숫자를 그린다. 이 store 는 FCM Service / NotificationViewModel / RootViewModel 사이에서
+ * 공유되어 push 도착·mark-read·로그아웃 시점에 배지 숫자를 일관되게 동기화한다.
+ *
+ * 서버 unread-count API 도입 전까지는 클라 push 카운터로만 동작하며,
+ * NotificationViewModel 가 알림 목록을 로드할 때 서버 기준 unread 수로 재정렬된다.
+ */
+@Singleton
+class UnreadBadgeStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val prefs by lazy {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    fun get(): Int = prefs.getInt(KEY_UNREAD, 0).coerceAtLeast(0)
+
+    fun set(count: Int) {
+        prefs.edit().putInt(KEY_UNREAD, count.coerceAtLeast(0)).apply()
+    }
+
+    fun incrementAndGet(): Int {
+        val next = (prefs.getInt(KEY_UNREAD, 0) + 1).coerceAtLeast(0)
+        prefs.edit().putInt(KEY_UNREAD, next).apply()
+        return next
+    }
+
+    fun clear() {
+        prefs.edit().remove(KEY_UNREAD).apply()
+    }
+}

--- a/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
+++ b/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
@@ -12,8 +12,13 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.mongle.android.MainActivity
+import com.mongle.android.data.local.UnreadBadgeStore
+import com.mongle.android.util.AppForegroundTracker
 import com.ycompany.Monggle.R
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class MongleFcmService : FirebaseMessagingService() {
 
     companion object {
@@ -21,6 +26,9 @@ class MongleFcmService : FirebaseMessagingService() {
         // AtomicInteger 단조 증가로 알림 ID 충돌을 원천 차단.
         private val notificationIdSeq = java.util.concurrent.atomic.AtomicInteger(1000)
     }
+
+    @Inject lateinit var unreadBadgeStore: UnreadBadgeStore
+    @Inject lateinit var appForegroundTracker: AppForegroundTracker
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
@@ -39,10 +47,19 @@ class MongleFcmService : FirebaseMessagingService() {
         val title = message.notification?.title ?: message.data["title"] ?: return
         val body = message.notification?.body ?: message.data["body"] ?: ""
         val type = message.data["type"] ?: ""
-        showNotification(title, body, type)
+
+        // iOS MG-55 패리티 — 로그인/온보딩/약관 도중에는 트레이 배너로 흐름을 끊지 않는다.
+        // unread 카운터는 그대로 증가시켜 사용자가 인증 후 알림 화면에서 누적 확인 가능.
+        if (appForegroundTracker.isInAuthFlow()) {
+            unreadBadgeStore.incrementAndGet()
+            return
+        }
+
+        val unread = unreadBadgeStore.incrementAndGet()
+        showNotification(title, body, type, unread)
     }
 
-    private fun showNotification(title: String, body: String, type: String = "") {
+    private fun showNotification(title: String, body: String, type: String, unread: Int) {
         val channelId = "mongle_default"
         val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
@@ -74,6 +91,9 @@ class MongleFcmService : FirebaseMessagingService() {
             .setContentText(body)
             .setAutoCancel(true)
             .setPriority(priority)
+            // iOS MG-39 패리티 — 런처 아이콘 배지에 미읽음 숫자 표시. Pixel/One UI 등 setNumber
+            // 를 지원하는 런처에서 active. 미지원 런처에서는 dot 만 표시되며 이 값은 무시된다.
+            .setNumber(unread)
             .setContentIntent(pending)
             .build()
 

--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationViewModel.kt
@@ -5,6 +5,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.ViewModel
 import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.viewModelScope
+import com.mongle.android.data.local.UnreadBadgeStore
 import com.mongle.android.data.remote.AppNotification
 import com.mongle.android.data.remote.ApiNotificationRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -33,12 +34,19 @@ data class NotificationUiState(
 @HiltViewModel
 class NotificationViewModel @Inject constructor(
     private val notificationRepository: ApiNotificationRepository,
+    private val unreadBadgeStore: UnreadBadgeStore,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     /** 미읽음 수를 notifications 기준으로 재계산해 stored 값으로 반영한다. */
-    private fun refreshDerived(state: NotificationUiState): NotificationUiState =
-        state.copy(unreadCount = state.notifications.count { !it.isRead })
+    private fun refreshDerived(state: NotificationUiState): NotificationUiState {
+        val next = state.copy(unreadCount = state.notifications.count { !it.isRead })
+        // iOS MG-39 패리티 — 알림 mutation/load 직후 OS 아이콘 배지 숫자를 동기화한다.
+        // setNumber() 가 적용된 활성 알림에는 영향이 없지만, 다음 push 도착 시점부터
+        // 사용자가 mark-read 한 상태에 맞춰 정확한 카운터로 시작한다.
+        unreadBadgeStore.set(next.unreadCount)
+        return next
+    }
 
     /**
      * 인앱에서 알림을 모두 읽음/삭제 처리한 시점에 OS 알림 트레이의 푸시도 정리한다.

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -10,12 +10,14 @@ import com.mongle.android.domain.model.MongleGroup
 import com.mongle.android.domain.model.Question
 import com.mongle.android.domain.model.TreeProgress
 import com.mongle.android.domain.model.User
+import com.mongle.android.data.local.UnreadBadgeStore
 import com.mongle.android.data.remote.SessionExpiredNotifier
 import com.mongle.android.domain.repository.AuthRepository
 import com.mongle.android.domain.repository.MongleRepository
 import com.mongle.android.domain.repository.QuestionRepository
 import com.mongle.android.domain.repository.TreeRepository
 import com.mongle.android.domain.repository.UserRepository
+import com.mongle.android.util.AppForegroundTracker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Job
@@ -23,6 +25,8 @@ import retrofit2.HttpException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -79,6 +83,8 @@ class RootViewModel @Inject constructor(
     private val treeRepository: TreeRepository,
     private val userRepository: UserRepository,
     private val sessionExpiredNotifier: SessionExpiredNotifier,
+    private val unreadBadgeStore: UnreadBadgeStore,
+    private val appForegroundTracker: AppForegroundTracker,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
@@ -114,6 +120,8 @@ class RootViewModel @Inject constructor(
         // 토큰 만료(401 + 갱신 실패) 이벤트 구독 → 안내 팝업 + 로그인 화면 (iOS MG-33 패리티)
         viewModelScope.launch {
             sessionExpiredNotifier.events.collect {
+                // 세션 만료 시 이전 사용자 잔존 배지 카운터를 폐기해 다음 로그인 사용자에 혼입되지 않게 한다.
+                unreadBadgeStore.clear()
                 _uiState.update {
                     RootUiState(
                         appState = AppState.Unauthenticated,
@@ -122,6 +130,29 @@ class RootViewModel @Inject constructor(
                 }
             }
         }
+        // iOS MG-55 패리티 — appState 변경을 AppForegroundTracker 에 반영해
+        // FCM Service 가 인증 흐름 화면(로그인/온보딩/약관) 도중 트레이 배너를 노출하지 않도록 한다.
+        viewModelScope.launch {
+            _uiState
+                .map { it.appState }
+                .distinctUntilChanged()
+                .collect { state -> syncForegroundTracker(state) }
+        }
+    }
+
+    private fun syncForegroundTracker(state: AppState) {
+        appForegroundTracker.currentScreen = when (state) {
+            AppState.Loading -> AppForegroundTracker.Screen.LOADING
+            AppState.Onboarding -> AppForegroundTracker.Screen.ONBOARDING
+            AppState.Unauthenticated -> AppForegroundTracker.Screen.UNAUTHENTICATED
+            AppState.EmailLogin -> AppForegroundTracker.Screen.EMAIL_LOGIN
+            AppState.EmailSignup -> AppForegroundTracker.Screen.EMAIL_SIGNUP
+            AppState.ConsentRequired -> AppForegroundTracker.Screen.CONSENT_REQUIRED
+            AppState.GroupSelection -> AppForegroundTracker.Screen.GROUP_SELECTION
+            AppState.Authenticated -> AppForegroundTracker.Screen.AUTHENTICATED
+        }
+        appForegroundTracker.isAuthenticated =
+            state == AppState.Authenticated || state == AppState.GroupSelection
     }
 
     /** sessionExpired 안내 팝업 닫기 */
@@ -417,6 +448,8 @@ class RootViewModel @Inject constructor(
     private fun clearUserScopedPrefs() {
         context.getSharedPreferences("mongle_heart", Context.MODE_PRIVATE).edit().clear().apply()
         context.getSharedPreferences("fcm", Context.MODE_PRIVATE).edit().clear().apply()
+        // iOS MG-39 패리티 — 다음 사용자에게 이전 미읽음 카운터가 혼입되지 않도록 정리.
+        unreadBadgeStore.clear()
     }
 
     fun onAnswerSubmitted(answer: Answer? = null, isNewAnswer: Boolean = true) {

--- a/app/src/main/java/com/mongle/android/util/AppForegroundTracker.kt
+++ b/app/src/main/java/com/mongle/android/util/AppForegroundTracker.kt
@@ -1,0 +1,40 @@
+package com.mongle.android.util
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * iOS MG-55 패리티 — 인증 흐름(로그인/온보딩/약관) 화면에서는
+ * MongleFcmService 가 트레이 배너를 노출하지 않도록 현재 화면 상태를 알려주는,
+ * 프로세스 수명 동안 살아있는 신호 채널.
+ *
+ * Service 컨텍스트는 Activity/Composition 스택과 분리되어 있어 직접 현재 화면을
+ * 알 수 없다. RootViewModel 이 자신의 uiState.appState 를 이 tracker 에 반영하고,
+ * FCM Service 는 onMessageReceived 진입부에 이 값을 읽어 배너 노출 여부를 결정한다.
+ */
+@Singleton
+class AppForegroundTracker @Inject constructor() {
+
+    @Volatile
+    var currentScreen: Screen = Screen.LOADING
+
+    @Volatile
+    var isAuthenticated: Boolean = false
+
+    /**
+     * 인증 흐름 도중(로그인/온보딩/약관) 인지 여부.
+     * 이 동안 도착한 푸시는 트레이 배너 대신 unread store 만 갱신한다.
+     */
+    fun isInAuthFlow(): Boolean = !isAuthenticated && currentScreen.isAuthFlow
+
+    enum class Screen(val isAuthFlow: Boolean) {
+        LOADING(true),
+        ONBOARDING(true),
+        UNAUTHENTICATED(true),
+        EMAIL_LOGIN(true),
+        EMAIL_SIGNUP(true),
+        CONSENT_REQUIRED(true),
+        GROUP_SELECTION(false),
+        AUTHENTICATED(false)
+    }
+}


### PR DESCRIPTION
## Summary

Closes [MG-106](https://ycompany.atlassian.net/browse/MG-106). Two MG-83 follow-up gaps:

- **OS 아이콘 배지 숫자** (iOS MG-39 패리티) — `NotificationCompat.Builder.setNumber(unread)` 호출이 없어 Pixel/One UI 런처에서 dot 만 보이고 미읽음 수 미표시.
- **FCM 인증흐름 배너 가드** (iOS MG-55 패리티) — 로그인/온보딩/약관 도중 도착한 푸시가 priority LOW 배너로 트레이에 노출되어 인증 흐름을 방해.

## Changes

- `data/local/UnreadBadgeStore.kt` 신규 — SharedPreferences 백업 미읽음 카운터 single source of truth (@Singleton)
- `util/AppForegroundTracker.kt` 신규 — Service 컨텍스트에서 화면 상태 조회용 (@Singleton, Screen enum + isInAuthFlow())
- `MongleFcmService.kt` — `@AndroidEntryPoint`, store/tracker @Inject, 인증 흐름 도중 배너 skip + setNumber(unread) 적용
- `NotificationViewModel.kt` — store @Inject, refreshDerived() 에서 store.set(unreadCount) 동기화
- `RootViewModel.kt` — store/tracker @Inject, sessionExpired·logout 시 store.clear(), appState distinct collector 로 tracker 동기화

## Test plan

- [ ] Pixel/One UI 런처에서 새 푸시 도착 시 OS 아이콘에 미읽음 숫자 표시
- [ ] 알림 1건 mark-read 시 배지 -1, deleteAll 시 0
- [ ] 로그인/온보딩/약관 화면 도중 push 도착 시 트레이 배너 미노출, unread 카운터만 누적
- [ ] 로그아웃 후 다른 사용자 로그인 시 이전 unread 카운터 미혼입
- [ ] 세션 만료(401+refresh 실패) 시 unread 카운터 0 으로 리셋
- [ ] 일반 push 동작(타입별 진입) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)