### PR TITLE
fix(MG-107): split modal dismiss → toast/heart popup with 350ms delay

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
+++ b/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
@@ -22,8 +22,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -62,6 +64,7 @@ fun MongleNavHost(
     adManager: AdManager? = null
 ) {
     val uiState by rootViewModel.uiState.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
     // MG-98 회전·다크모드 후에도 오버레이/토스트 상태 유지.
     // Question?/User? 복합 객체는 Parcelable Saver 미정의로 rememberSaveable 자동 처리 불가 →
     // 회전 시 닫힘(현재 동작) 유지. boolean/int 만 saveable 처리.
@@ -289,11 +292,17 @@ fun MongleNavHost(
                             currentUserHearts = uiState.currentUser?.hearts ?: 0,
                             adManager = adManager,
                             onAnswerSubmitted = { answer, isNewAnswer ->
+                                // iOS MG-56 패리티 — modal dismiss 와 toast/heart popup 가 같은 프레임에
+                                // 발생해 race(토스트 깜빡임, 모달 dismiss 애니메이션 미완료)를 일으키지 않도록
+                                // close → 350ms delay → toast/heart popup 순서로 분리한다.
                                 rootViewModel.onAnswerSubmitted(answer, isNewAnswer)
                                 showQuestionDetail = null
-                                showAnswerSubmittedToast = true
-                                if (isNewAnswer) showHeartPopup = true
                                 answerSubmittedCount++
+                                coroutineScope.launch {
+                                    delay(350)
+                                    showAnswerSubmittedToast = true
+                                    if (isNewAnswer) showHeartPopup = true
+                                }
                             },
                             onClose = { showQuestionDetail = null }
                         )


### PR DESCRIPTION
## Summary

Closes [MG-107](https://ycompany.atlassian.net/browse/MG-107). MG-86 #4 follow-up. iOS MG-56 패리티.

답변 제출 성공 직후 modal close, 토스트 트리거, 하트 팝업이 같은 프레임에 발생해 저FPS 디바이스에서 modal dismiss 애니메이션과 토스트가 겹쳐 깜빡임/잘림이 발생할 수 있었음. iOS 와 동일하게 close → 350ms delay → toast/heart popup 순으로 분리.

## Changes

- `MongleNavHost.kt` — `rememberCoroutineScope()` 도입, `onAnswerSubmitted` 콜백에서 modal close 즉시 실행하고 `coroutineScope.launch { delay(350); toast/heart popup }` 으로 분리

## Test plan

- [ ] 답변 제출 후 모달이 부드럽게 닫히고 약 0.35초 뒤 토스트가 깜빡임 없이 등장
- [ ] isNewAnswer == true 일 때 하트 팝업도 350ms 뒤 노출
- [ ] 답변 수정(isNewAnswer=false) 시 토스트만 노출, 하트 팝업 미노출
- [ ] 저사양/저FPS 디바이스에서 화면 잘림 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)