### PR TITLE
fix(MG-108): extract DateFormatter patterns to strings.xml

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/notification/NotificationScreen.kt
@@ -492,14 +492,9 @@ private fun timeAgo(createdAt: String, res: Resources): String {
         diffHours < 24 -> res.getString(R.string.notif_time_hour, diffHours.toInt())
         diffDays < 7 -> res.getString(R.string.notif_time_day, diffDays.toInt())
         else -> {
-            // iOS MG-38 패리티 — 7일 이상 fallback 도 로케일 분기
-            val locale = Locale.getDefault()
-            val pattern = when (locale.language) {
-                "ko" -> "M월 d일"
-                "ja" -> "M月d日"
-                else -> "M/d"
-            }
-            SimpleDateFormat(pattern, locale).format(date)
+            // iOS MG-38 패리티 — 7일 이상 fallback 패턴은 strings.xml 리소스 기반.
+            val pattern = res.getString(R.string.notif_date_pattern)
+            SimpleDateFormat(pattern, Locale.getDefault()).format(date)
         }
     }
 }

--- a/app/src/main/java/com/mongle/android/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/search/SearchViewModel.kt
@@ -1,15 +1,18 @@
 package com.mongle.android.ui.search
 
+import android.content.Context
 import android.util.Log
 import com.mongle.android.ui.common.AppError
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ycompany.Monggle.BuildConfig
+import com.ycompany.Monggle.R
 import com.mongle.android.domain.model.DailyQuestionHistory
 import com.mongle.android.domain.model.HistoryAnswerSummary
 import com.mongle.android.domain.repository.MongleRepository
 import com.mongle.android.domain.repository.QuestionRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -64,7 +67,8 @@ data class SearchUiState(
 @HiltViewModel
 class SearchViewModel @Inject constructor(
     private val questionRepository: QuestionRepository,
-    private val mongleRepository: MongleRepository
+    private val mongleRepository: MongleRepository,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SearchUiState())
@@ -205,13 +209,19 @@ class SearchViewModel @Inject constructor(
 
     private fun makeSections(results: List<SearchResultItem>): List<SearchResultSection> {
         if (results.isEmpty()) return emptyList()
+        // iOS MG-38 패리티 — 하드코딩 한국어/일본어 분기 대신 strings.xml 리소스 기반.
+        val locale = java.util.Locale.getDefault()
+        val pattern = context.getString(R.string.search_date_pattern)
+        val todayLabel = " · " + context.getString(R.string.search_today)
+        val yesterdayLabel = " · " + context.getString(R.string.search_yesterday)
+        val formatter = java.text.SimpleDateFormat(pattern, locale)
         val grouped = results.groupBy { it.date.toDateKeyMillis() }
         return grouped.entries.sortedByDescending { it.key }.map { (key, items) ->
             val firstDate = items.first().date
             SearchResultSection(
                 dateKey = key,
                 date = firstDate,
-                displayLabel = firstDate.toDisplayLabel(),
+                displayLabel = firstDate.toDisplayLabel(formatter, todayLabel, yesterdayLabel),
                 items = items
             )
         }
@@ -263,26 +273,24 @@ private fun Date.toDateKeyMillis(): Long {
     return cal.timeInMillis
 }
 
-/** Date를 표시 문자열로 포맷 (오늘/어제/날짜) — 시스템 로케일 기반 i18n (iOS MG-38 패리티) */
-fun Date.toDisplayLabel(): String {
-    val locale = java.util.Locale.getDefault()
-    val pattern = when (locale.language) {
-        "ko" -> "M월 d일"
-        "ja" -> "M月d日"
-        else -> "MMM d"
-    }
-    val datePart = java.text.SimpleDateFormat(pattern, locale).format(this)
-
+/**
+ * Date 를 표시 문자열로 포맷 (오늘/어제/날짜) — strings.xml 기반 i18n (iOS MG-38 패리티).
+ * 패턴/오늘/어제 레이블은 호출부에서 리소스 해상도 후 주입한다(SearchViewModel.makeSections).
+ */
+fun Date.toDisplayLabel(
+    formatter: java.text.SimpleDateFormat,
+    todaySuffix: String,
+    yesterdaySuffix: String
+): String {
+    val datePart = formatter.format(this)
     val cal = Calendar.getInstance().apply { time = this@toDisplayLabel }
     val today = Calendar.getInstance()
     val yesterday = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, -1) }
     val suffix = when {
         cal.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
-            cal.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR) ->
-            when (locale.language) { "ko" -> " · 오늘"; "ja" -> " · 今日"; else -> " · Today" }
+            cal.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR) -> todaySuffix
         cal.get(Calendar.YEAR) == yesterday.get(Calendar.YEAR) &&
-            cal.get(Calendar.DAY_OF_YEAR) == yesterday.get(Calendar.DAY_OF_YEAR) ->
-            when (locale.language) { "ko" -> " · 어제"; "ja" -> " · 昨日"; else -> " · Yesterday" }
+            cal.get(Calendar.DAY_OF_YEAR) == yesterday.get(Calendar.DAY_OF_YEAR) -> yesterdaySuffix
         else -> ""
     }
     return "$datePart$suffix"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -385,4 +385,10 @@
     <string name="demo_char_3">ほっこりさん</string>
     <string name="demo_char_4">あったかさん</string>
     <string name="demo_char_5">きもちさん</string>
+
+    <!-- iOS MG-38 패리티: DateFormatter 한국어 하드코딩 제거 -->
+    <string name="search_today">今日</string>
+    <string name="search_yesterday">昨日</string>
+    <string name="search_date_pattern">M月d日</string>
+    <string name="notif_date_pattern">M月d日</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -385,4 +385,10 @@
     <string name="demo_char_3">포근이</string>
     <string name="demo_char_4">따뜻이</string>
     <string name="demo_char_5">느낌이</string>
+
+    <!-- iOS MG-38 패리티: DateFormatter 한국어 하드코딩 제거 -->
+    <string name="search_today">오늘</string>
+    <string name="search_yesterday">어제</string>
+    <string name="search_date_pattern">M월 d일</string>
+    <string name="notif_date_pattern">M월 d일</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,4 +385,11 @@
     <string name="demo_char_3">Pogeun</string>
     <string name="demo_char_4">Ttatteut</string>
     <string name="demo_char_5">Neukkim</string>
+
+    <!-- iOS MG-38 패리티: DateFormatter 한국어 하드코딩 제거. SimpleDateFormat 패턴/레이블을
+         로케일별 문자열 리소스로 분리해 ko/en/ja 모두 자연스러운 표기를 보장. -->
+    <string name="search_today">Today</string>
+    <string name="search_yesterday">Yesterday</string>
+    <string name="search_date_pattern">MMM d</string>
+    <string name="notif_date_pattern">M/d</string>
 </resources>


### PR DESCRIPTION
## Summary

Closes [MG-108](https://ycompany.atlassian.net/browse/MG-108). MG-91 follow-up. iOS MG-38 패리티.

MG-91 1차 작업에서 `Locale.getDefault()` 기반 패턴 분기는 적용했지만, 패턴/오늘·어제 레이블이 ViewModel/Composable 내부에 인라인 하드코딩되어 신규 로케일 추가 시 코드 수정이 강제됨. iOS 와 동일하게 `strings.xml` 리소스 키로 분리.

## Changes

- `values/values-ko/values-ja/strings.xml` — 4개 키 추가:
  - `search_today` / `search_yesterday`
  - `search_date_pattern` (Search 결과 그룹 헤더 패턴)
  - `notif_date_pattern` (알림 7일+ fallback 패턴)
- `SearchViewModel.kt` — `@ApplicationContext Context` 주입. `makeSections()` 에서 `R.string.*` 사용. `toDisplayLabel()` 시그니처를 formatter/labels 파라미터화로 변경.
- `NotificationScreen.kt` — `res.getString(R.string.notif_date_pattern)` 사용

## Test plan

- [ ] ko/en/ja 3개 로케일에서 Search 결과 그룹 헤더와 NotificationScreen 7일+ 표기 검증
- [ ] "오늘"/"어제" 레이블이 시스템 로케일에 따라 자동 분기되는지
- [ ] 한국어 설정 시 기존 표기 그대로 유지되는지
- [ ] 향후 신규 로케일 추가 시 코드 수정 없이 strings.xml 추가만으로 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)