### PR TITLE
fix(push): 알림 탭 시 자동 markAsRead + 배지 -1 (MG-111)

### DIFF
--- a/app/src/main/java/com/mongle/android/MainActivity.kt
+++ b/app/src/main/java/com/mongle/android/MainActivity.kt
@@ -33,7 +33,10 @@ class MainActivity : ComponentActivity() {
         // 그 외 지역은 동의 폼 표시 후 AdMob 초기화한다.
         consentManager.gatherConsent(this)
         intent?.data?.let { uri -> rootViewModel.handleDeepLink(uri) }
-        intent?.getStringExtra("notification_type")?.let { rootViewModel.handleNotificationTap(it) }
+        rootViewModel.handleNotificationTap(
+            intent?.getStringExtra("notification_type"),
+            intent?.getStringExtra("notification_id")
+        )
         setContent {
             MongleTheme {
                 MongleNavHost(
@@ -57,6 +60,9 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         intent.data?.let { uri -> rootViewModel.handleDeepLink(uri) }
-        intent.getStringExtra("notification_type")?.let { rootViewModel.handleNotificationTap(it) }
+        rootViewModel.handleNotificationTap(
+            intent.getStringExtra("notification_type"),
+            intent.getStringExtra("notification_id")
+        )
     }
 }

--- a/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
+++ b/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
@@ -47,6 +47,9 @@ class MongleFcmService : FirebaseMessagingService() {
         val title = message.notification?.title ?: message.data["title"] ?: return
         val body = message.notification?.body ?: message.data["body"] ?: ""
         val type = message.data["type"] ?: ""
+        // 서버(MG-111)가 페이로드에 notificationId 를 실어 보낸다 — PendingIntent 로 전달해
+        // 사용자가 트레이 알림을 탭한 시점에 자동 markAsRead 하기 위함.
+        val notificationId = message.data["notificationId"]
 
         // iOS MG-55 패리티 — 로그인/온보딩/약관 도중에는 트레이 배너로 흐름을 끊지 않는다.
         // unread 카운터는 그대로 증가시켜 사용자가 인증 후 알림 화면에서 누적 확인 가능.
@@ -56,10 +59,10 @@ class MongleFcmService : FirebaseMessagingService() {
         }
 
         val unread = unreadBadgeStore.incrementAndGet()
-        showNotification(title, body, type, unread)
+        showNotification(title, body, type, unread, notificationId)
     }
 
-    private fun showNotification(title: String, body: String, type: String, unread: Int) {
+    private fun showNotification(title: String, body: String, type: String, unread: Int, notificationId: String?) {
         val channelId = "mongle_default"
         val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
@@ -73,9 +76,15 @@ class MongleFcmService : FirebaseMessagingService() {
         val intent = Intent(this, MainActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             putExtra("notification_type", type)
+            // MG-111 — MainActivity 가 onCreate/onNewIntent 에서 추출해 markAsRead 호출.
+            if (notificationId != null) putExtra("notification_id", notificationId)
         }
+        // requestCode 가 0 으로 고정이면 FLAG_IMMUTABLE 환경에서 시스템이 기존 PendingIntent
+        // 를 재사용해 신규 extra(notification_id 등)가 반영되지 않는다. 알림별로 다른
+        // requestCode 를 부여해 PendingIntent 를 분리. (MG-111)
+        val requestCode = notificationId?.hashCode() ?: System.currentTimeMillis().toInt()
         val pending = PendingIntent.getActivity(
-            this, 0, intent, PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+            this, requestCode, intent, PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
         )
 
         // 앱이 foreground 일 때 heads-up 배너로 흐름을 끊지 않도록 priority 를 낮춘다.

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -11,6 +11,7 @@ import com.mongle.android.domain.model.Question
 import com.mongle.android.domain.model.TreeProgress
 import com.mongle.android.domain.model.User
 import com.mongle.android.data.local.UnreadBadgeStore
+import com.mongle.android.data.remote.ApiNotificationRepository
 import com.mongle.android.data.remote.SessionExpiredNotifier
 import com.mongle.android.domain.repository.AuthRepository
 import com.mongle.android.domain.repository.MongleRepository
@@ -84,6 +85,7 @@ class RootViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val sessionExpiredNotifier: SessionExpiredNotifier,
     private val unreadBadgeStore: UnreadBadgeStore,
+    private val notificationRepository: ApiNotificationRepository,
     private val appForegroundTracker: AppForegroundTracker,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
@@ -326,8 +328,20 @@ class RootViewModel @Inject constructor(
         _uiState.update { it.copy(pendingInviteCode = null) }
     }
 
-    fun handleNotificationTap(type: String) {
-        _uiState.update { it.copy(pendingNotificationType = type) }
+    fun handleNotificationTap(type: String?, notificationId: String? = null) {
+        if (type != null) {
+            _uiState.update { it.copy(pendingNotificationType = type) }
+        }
+        // MG-111 — 트레이 알림 탭 시 서버 알림을 즉시 읽음 처리하고 배지 카운트를 -1.
+        // 알림함 화면 진입 없이 사용자가 푸시만 탭한 케이스에서 unread 가 누적되지 않게 한다.
+        // 실패 시 NotificationViewModel 가 알림함 진입 시 서버 기준으로 재정렬하므로 silent.
+        if (notificationId != null) {
+            viewModelScope.launch {
+                runCatching { notificationRepository.markAsRead(notificationId) }
+                val current = unreadBadgeStore.get()
+                unreadBadgeStore.set((current - 1).coerceAtLeast(0))
+            }
+        }
     }
 
     fun clearPendingNotification() {


### PR DESCRIPTION
## Summary
- 트레이 알림 탭만으로 서버 unread 처리 + 런처 배지 즉시 갱신
- iOS#3 "안드로이드도 확인할 것" 패리티

## Changes
- `MongleFcmService.onMessageReceived`: `message.data["notificationId"]` 추출 → PendingIntent extra `notification_id` 로 전달
- `MongleFcmService.showNotification`: PendingIntent `requestCode` 를 `notificationId.hashCode()` 로 부여 (0 고정 시 FLAG_IMMUTABLE 에서 기존 PI 재사용으로 신규 extra 가 무시되던 잠재 결함 차단)
- `MainActivity.onCreate/onNewIntent`: extra 추출 → `RootViewModel.handleNotificationTap(type, notificationId)`
- `RootViewModel`: `ApiNotificationRepository` 의존성 추가, `handleNotificationTap` 시그니처 확장. 호출 시 `markAsRead` + `UnreadBadgeStore.set(current - 1)`

## 의존
- `Mongle-Server#56` (페이로드에 `notificationId` 포함) 머지 + 배포 후 효과 체감

## Side effects
- `viewModelScope` 코루틴 → UI 차단 없음
- markAsRead 실패는 `runCatching` 으로 silent — NotificationViewModel 가 알림함 진입 시 서버 기준 재정렬
- type 만 있고 notificationId 없는 구 페이로드도 그대로 동작 (backward-compat)

## 미해결
- AOS#4 (iOS 에서 작성/재촉 알림 못 받음 = iOS#1 의 패리티) 는 데이터/토큰 진단 영역 — 별도 follow-up

## Test plan
- [x] `./gradlew :app:assembleDebug` 성공
- [ ] FCM 콘솔 / 서버에서 notificationId 페이로드 송신 → 백그라운드 탭 → 서버 `Notification.isRead = true`
- [ ] UnreadBadgeStore -1 → setNumber 갱신 (Pixel/One UI 확인)
- [ ] type only 구 페이로드 동작 무영향
- [ ] Auth Flow(로그인/온보딩/약관) 도중 푸시 수신 → 트레이 미표시 + unread 누적 동작 그대로

🤖 Generated with [Claude Code](https://claude.com/claude-code)