### PR TITLE
fix(aos): 16 KB page size 지원 (MG-112)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,16 @@ android {
         compose = true
         buildConfig = true
     }
+
+    // Android 15+ 16 KB page size 지원 — .so 를 무압축으로 패키징해 시스템이
+    // mmap 할 때 16 KB aligned segment 그대로 사용하게 한다. AGP 8.0+ 기본값이지만
+    // 명시해 회귀 방지. 16 KB 미지원 native lib 가 transitive 로 들어오면 Play
+    // Console "Devices with 16 KB page size" 보고서에서 추적 가능.
+    packaging {
+        jniLibs {
+            useLegacyPackaging = false
+        }
+    }
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-agp = "8.3.2"
+# AGP 8.5.1+ 부터 16 KB page size alignment 빌드 산출물 생성. 8.7.x = 안정 라인.
+agp = "8.7.3"
 kotlin = "2.0.21"
 kotlinxCoroutines = "1.8.1"
 junit = "4.13.2"
@@ -14,14 +15,17 @@ lifecycle = "2.8.6"
 material3 = "1.3.0"
 googleServices = "4.4.2"
 playServicesAuth = "21.2.0"
-kakaoAuth = "2.20.3"
+# 16KB-aligned native libs (2.21.x 부터)
+kakaoAuth = "2.21.4"
 androidxBrowser = "1.8.0"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
 moshi = "1.15.1"
-googleMobileAds = "23.3.0"
+# 16KB-aligned native libs (23.6.0 부터)
+googleMobileAds = "23.6.0"
 userMessagingPlatform = "3.1.0"
-firebaseBom = "33.1.0"
+# 16KB-aligned native libs (BOM 33.7.0 부터)
+firebaseBom = "33.7.0"
 securityCrypto = "1.1.0-alpha06"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Android 15+ 16 KB page size 디바이스에서 앱이 정상 mmap 되도록 빌드 인프라 + 핵심 native lib 의존성을 16 KB-aligned 조합으로 정합
- Play Console 16 KB 호환 정책 deadline 대비 (신규 앱 2025-11, 기존 앱 2026-11)

## Changes
| 항목 | 변경 |
|---|---|
| AGP | 8.3.2 → **8.7.3** (.so alignment 빌드 파이프라인) |
| Gradle wrapper | 8.7 → **8.10.2** (AGP 8.7 호환) |
| Firebase BOM | 33.1.0 → **33.7.0** |
| play-services-ads | 23.3.0 → **23.6.0** |
| Kakao SDK | 2.20.3 → **2.21.4** |
| `packaging.jniLibs.useLegacyPackaging` | (default) → **명시 false** |

모두 minor 업그레이드. 회귀 면적 최소화.

## 검증
- Debug APK 내 유일한 native lib `lib/arm64-v8a/libandroidx.graphics.path.so` 의 ELF program header `LOAD` segment `p_align = 2^14 = 16384` (= 16 KB) 확인
- 이 프로젝트는 native lib 사용 면적이 매우 작아(`androidx.graphics.path` 1개) 16 KB 미준수 의존성 추가 시 Play Console "Devices with 16 KB page size" 보고서로 즉시 추적 가능

## Side effects
- AGP 8.4 → 8.5: namespace 필수 (이미 적용), 일부 deprecated API
- Firebase / Ads / Kakao 모두 minor — public API 무변경, 동작 회귀 위험 낮음
- Gradle 8.10.2: configuration cache 안정성 개선 (현재 활성화 안 됨, 영향 없음)

## Test plan
- [x] `./gradlew :app:assembleDebug` 성공 (AGP 8.7.3, Gradle 8.10.2)
- [x] Debug APK `.so` 16 KB alignment 확인
- [ ] 16 KB page size 에뮬레이터(Android 15 system image) 에서 앱 실행 + 카톡/구글 로그인 / 푸시 / AdMob 배너 정상
- [ ] Play Console 내부 테스트 트랙 업로드 → "Devices with 16 KB page size" 보고서 OK
- [ ] Release 빌드 (keystore 환경) — R8 minify + alignment 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)