### PR TITLE
fix(aos-question): 그룹 전환 시 직전 그룹의 myAnswer carry-over 차단 (MG-113)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/QuestionDetailViewModel.kt
@@ -75,18 +75,29 @@ class QuestionDetailViewModel @Inject constructor(
 
     private var initialized = false
 
+    /**
+     * MG-113 — QuestionDetailScreen 은 NavHost 외부의 조건부 composition 으로 렌더되어
+     * hiltViewModel() 이 Activity-scoped 단일 인스턴스에 바인딩된다. 그룹 전환으로
+     * 다른 question 이 들어와도 initialized=true 가 유지되어 직전 그룹의 myAnswer/
+     * answerText 가 carry-over → "수정하기" 버튼이 잘못 표시되던 버그 차단.
+     *
+     * question.id 또는 currentUser.id 가 바뀌면 (그룹 전환 / 계정 전환) state 를 완전
+     * 초기화하고 새 답변을 로드한다. 같은 context 재진입(부모 리컴포지션) 은 기존 동작 유지.
+     */
     fun initialize(question: Question, currentUser: User?, familyMembers: List<User> = emptyList(), hearts: Int = 0) {
-        if (initialized) return
+        val current = _uiState.value
+        val isSameContext = initialized
+            && current.question?.id == question.id
+            && current.currentUser?.id == currentUser?.id
+        if (isSameContext) return
         initialized = true
-        _uiState.update {
-            it.copy(
-                question = question,
-                currentUser = currentUser,
-                familyMembers = familyMembers,
-                hearts = hearts,
-                isLoading = true
-            )
-        }
+        _uiState.value = QuestionDetailUiState(
+            question = question,
+            currentUser = currentUser,
+            familyMembers = familyMembers,
+            hearts = hearts,
+            isLoading = true
+        )
         loadAnswers(question, currentUser)
         // 부모에서 캡처한 hearts 는 stale 일 수 있음(다른 단말에서 답변/스킵/edit 으로 변경됨).
         // 진입 시 서버에서 최신 값을 가져와 editCostPopup/adReward 분기가 올바른 잔량으로 동작하게 한다.


### PR DESCRIPTION
## Summary
- 그룹 A 답변 후 그룹 B 진입 시 답변 화면이 "수정하기" 상태로 잘못 표시되던 버그 차단

## Root Cause
- `QuestionDetailScreen` 은 `MongleNavHost` 의 `Box` 안에서 조건부 composition (`currentQuestionDetail != null` 분기) 으로 렌더됨 — `NavHost` destination 이 아니므로 `hiltViewModel()` 이 NavBackStackEntry 가 아닌 **Activity-scoped 단일 인스턴스** 에 바인딩
- `QuestionDetailViewModel.initialize` 의 `initialized` 플래그가 한 번 true 가 되면 reset 없이 유지 → 그룹 전환으로 새 question 진입 시에도 즉시 return → 직전 그룹의 `myAnswer`, `answerText` 가 그대로 → `hasMyAnswer = true` 에 의해 버튼이 "수정하기" 로 표시

## Changes
- `QuestionDetailViewModel.initialize`: `question.id` / `currentUser.id` 변경 감지 (그룹 전환 / 계정 전환). 다른 context 진입 시 `_uiState.value = QuestionDetailUiState(...)` 로 완전 초기화 후 `loadAnswers` + `refreshHearts`
- 같은 context 재진입(부모 리컴포지션) 은 기존 fast-path 그대로

## Side effects
- `it.copy(...)` → 새 `QuestionDetailUiState(...)` 교체로 `isSubmitting` / `showEditConfirmDialog` 등 잔존 dialog 상태도 함께 reset. context 변경 시 의도한 동작
- `LaunchedEffect(question, currentUser)` 가 question 변경마다 재발화하므로 자동 fix 적용
- 같은 question 재진입은 effect skip → 기존 답변 데이터/입력 텍스트 보존 (회귀 없음)

## 미해결 (별도 이슈로 둘 만한 부분)
- 근본 fix 는 `QuestionDetailScreen` 을 `NavHost` destination 으로 옮겨 NavBackStackEntry-scoped ViewModel 로 만드는 것. 이번 PR 은 최소 변경으로 동작 회복만 목표.

## Test plan
- [x] `./gradlew :app:assembleDebug` 성공
- [ ] 그룹 A 답변 → 그룹 B 전환 → 오늘의 질문 진입 → 빈 답변 입력 화면 + "답변 보내기" 버튼 (수정 X)
- [ ] 그룹 B 에서 답변 후 그룹 A 재진입 → 그룹 A 의 기존 답변 정상 표시 + "수정하기" 버튼
- [ ] 같은 그룹 내 nudge popup 등 modal close 후 재진입 시 입력 중이던 텍스트 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)