### PR TITLE
fix(aos-kakao): 카톡 로그인 fallback 분기 세분화 + 진단 로그 (MG-114)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/login/SocialLoginHelper.kt
+++ b/app/src/main/java/com/mongle/android/ui/login/SocialLoginHelper.kt
@@ -60,20 +60,43 @@ suspend fun loginWithKakao(context: Context): KakaoLoginCredential =
             }
         }
 
+        // MG-114 — KakaoTalk login fallback 분기를 reason 별로 세분화.
+        // 이전엔 Cancelled 외 모든 오류를 무차별 loginWithKakaoAccount 로 재시도해
+        // 카톡 앱이 active 인 상태에서 race 로 fallback 도 실패 → 사용자 입장에선
+        // "카톡 → 앱 복귀 안 됨" 으로 인식되던 케이스를 차단. 또한 reason 별 로그를
+        // 남겨 logcat 으로 정확한 원인을 추적 가능하게 한다.
         if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            Log.d("KakaoLogin", "KakaoTalk available — attempting talk login")
             UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
-                if (error != null) {
-                    // 카카오톡 미설치 또는 사용자 취소가 아닌 경우 계정 로그인 시도
-                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
-                        cont.resumeWithException(error)
-                    } else {
-                        UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+                when {
+                    error == null && token != null -> callback(token, null)
+                    error == null -> cont.resumeWithException(Exception("카카오 로그인 실패: 토큰 없음"))
+                    error is ClientError -> when (error.reason) {
+                        ClientErrorCause.Cancelled -> {
+                            Log.d("KakaoLogin", "KakaoTalk login cancelled by user")
+                            cont.resumeWithException(error)
+                        }
+                        ClientErrorCause.NotSupported -> {
+                            // 카톡 앱이 OAuth 미지원 버전이거나 환경 미충족 → 계정 로그인으로 fallback (정상 경로).
+                            Log.d("KakaoLogin", "KakaoTalk login not supported (reason=${error.reason}) — fallback to account")
+                            UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+                        }
+                        else -> {
+                            // IllegalState / Unknown 등 — 기존 패턴 유지하되 명시 로깅.
+                            Log.e("KakaoLogin", "KakaoTalk login ClientError (reason=${error.reason}, msg=${error.msg}) — fallback to account", error)
+                            UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+                        }
                     }
-                } else {
-                    callback(token, null)
+                    else -> {
+                        // 비ClientError (네트워크/시스템) — 무차별 재시도 차단. 명확한 실패로 종료해
+                        // 사용자가 재시도 / 앱 재시작을 인지하게 한다.
+                        Log.e("KakaoLogin", "KakaoTalk login non-ClientError (${error::class.simpleName}: ${error.message})", error)
+                        cont.resumeWithException(error)
+                    }
                 }
             }
         } else {
+            Log.d("KakaoLogin", "KakaoTalk not available — account login")
             UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
         }
     }


### PR DESCRIPTION
## Summary
- 9fb745a (`<queries>` 추가) 이후에도 잔존하던 "카톡 로그인 시 앱으로 복귀되지 않는" 보고에 대한 추가 진단/방어 fix
- 무차별 fallback 으로 race 발생하던 케이스 차단 + reason 별 logcat 추적

## Root Cause 가설
- 기존 `loginWithKakao` 는 `Cancelled` 외 모든 오류를 `loginWithKakaoAccount` 로 무차별 재시도
- 카톡 앱이 background 로 돌아오지 않은 상태에서 fallback 호출 → 카톡과 race → fallback 도 실패하면서 사용자 입장에선 "앱이 멈춘 것"으로 보임
- 또한 logcat 에 reason 이 안 남아 사용자가 디버깅 불가

## Changes
`SocialLoginHelper.loginWithKakao` 의 `loginWithKakaoTalk` callback 분기 세분화:
| reason | 동작 |
|---|---|
| `Cancelled` | cancel 종료 (기존 유지) |
| `NotSupported` | 계정 로그인 fallback (정상) |
| 그 외 ClientError | fallback 유지하되 reason/msg 명시 로깅 |
| 비 ClientError (네트워크/시스템) | **fallback 차단**, 명확한 실패 종료 |

## 의존
- **MG-112** (Kakao SDK 2.20.3 → 2.21.4 + AGP 8.7.3) 와 함께 머지/배포되면 완전 fix 가능성 ↑

## Side effects
- 카톡 미설치 / 사용자 취소 등 정상 경로는 기존과 동일
- 비 ClientError 시 silent fallback → 명확한 에러로 변경 — 사용자가 재시도/앱 재시작을 인지하게 됨 (UX 회귀 아닌 개선)
- logcat tag `KakaoLogin` 으로 reason / msg 추적 가능

## Test plan
- [x] `./gradlew :app:assembleDebug` 성공
- [ ] 카톡 설치 + 로그인 → 카톡 → Mongle 정상 복귀
- [ ] 카톡 설치 + 사용자 취소 → "취소" 에러 (fallback 안 함)
- [ ] 카톡 미설치 → 계정 로그인(웹) 정상 진행
- [ ] 비행기 모드 → 명확한 네트워크 에러 + logcat 기록
- [ ] logcat `KakaoLogin` 태그로 분기 추적 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)