### PR TITLE
fix(aos-ui): 몽글 캐릭터 눈/점프 iOS 수치로 정합 (MG-115)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/common/MongleCharacter.kt
+++ b/app/src/main/java/com/mongle/android/ui/common/MongleCharacter.kt
@@ -88,7 +88,8 @@ fun MongleCharacter(
     val bodyColor = color ?: characterColors[index % characterColors.size]
     val eyeSize = size * 0.18f
     val eyeHOffset = size * 0.144f
-    val eyeVOffset = size * 0.07f
+    // MG-115 — iOS MongleMonggle 의 eyeOffset = size * 0.04 와 일치 (0.07f → 0.04f).
+    val eyeVOffset = size * 0.04f
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -162,7 +163,8 @@ fun MongleCharacterAvatar(
     val bodyColor = color ?: characterColors[index % characterColors.size]
     val eyeSize = size * 0.18f
     val eyeHOffset = size * 0.144f
-    val eyeVOffset = size * 0.07f
+    // MG-115 — iOS MongleMonggle 의 eyeOffset = size * 0.04 와 일치 (0.07f → 0.04f).
+    val eyeVOffset = size * 0.04f
 
     Box(
         modifier = modifier
@@ -291,7 +293,8 @@ fun MongleSceneView(
 ) {
     val density = LocalDensity.current
     // 화면 밀도에 맞는 실제 픽셀 크기 사용 (화면 밖 이탈 방지)
-    val charSizePx = with(density) { 52.dp.toPx() }
+    // MG-115 — iOS MongleMonggle 기본 size 56pt 와 매칭 (52 → 56).
+    val charSizePx = with(density) { 56.dp.toPx() }
     val collisionRadius = charSizePx * 1.5f
     val wallPadding = charSizePx * 0.9f
     val stepSize = with(density) { 1.8.dp.toPx() }
@@ -343,10 +346,10 @@ fun MongleSceneView(
         }
     }
 
-    // 물리 루프 - iOS와 동일하게 120ms 간격
+    // 물리 루프 — iOS MongleSceneView 의 interval=0.16s (160ms) 와 매칭 (MG-115).
     LaunchedEffect(Unit) {
         while (true) {
-            delay(120)
+            delay(160)
             if (sceneMembers.isEmpty()) continue
             val s = sceneSize
             if (s.width <= 0 || s.height <= 0) continue
@@ -484,10 +487,13 @@ private fun AnimatedSceneMemberBox(
     onAnswerFirstToView: (String) -> Unit,
     onAnswerFirstToNudge: (String) -> Unit,
 ) {
-    val animSpec = tween<Float>(durationMillis = 110, easing = LinearEasing)
+    // MG-115 — iOS MongleSceneView 의 step interval(0.16s) 와 sin 주기(π/5.0) +
+    // hop 진폭(12pt) 으로 정합. 이전 (110ms / π/4.0 / 14dp) 은 사이클이 빠르고 진폭이
+    // 달라 사용자가 점프가 낮게 인지되던 문제 차단.
+    val animSpec = tween<Float>(durationMillis = 150, easing = LinearEasing)
     val animX by animateFloatAsState(targetValue = member.x, animationSpec = animSpec, label = "x")
     val animY by animateFloatAsState(targetValue = member.y, animationSpec = animSpec, label = "y")
-    val hopTarget = (-abs(sin(member.stepCount * PI / 4.0)) * 14).toFloat()
+    val hopTarget = (-abs(sin(member.stepCount * PI / 5.0)) * 12).toFloat()
     val animHop by animateFloatAsState(targetValue = hopTarget, animationSpec = animSpec, label = "hop")
     val half = (charSizePx / 2).roundToInt()
 
@@ -548,7 +554,8 @@ private fun SceneMongleItem(
     val size = 52.dp
     val eyeSize = size * 0.18f
     val eyeHOffset = size * 0.144f
-    val eyeVOffset = size * 0.07f
+    // MG-115 — iOS MongleMonggle 의 eyeOffset = size * 0.04 와 일치 (0.07f → 0.04f).
+    val eyeVOffset = size * 0.04f
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         // 상태 배지

--- a/app/src/main/java/com/mongle/android/ui/question/QuestionDetailScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/question/QuestionDetailScreen.kt
@@ -399,13 +399,18 @@ private fun MoodCell(
                 .background(mood.color, CircleShape),
             contentAlignment = Alignment.Center
         ) {
+            // MG-115 — iOS MongleMonggle 와 일치하도록 정합:
+            // eyeHOffset = size * 0.144, eyeVOffset = size * 0.04 (아래로),
+            // 흰 테두리 두께 +3dp. 이전엔 y 가 -eyeSize * 0.3f (위로!) 로 그려져
+            // iOS 와 정반대 방향이었다.
             val eyeSize = 36.dp * 0.18f
-            val eyeOffset = 36.dp * 0.14f
+            val eyeHOffset = 36.dp * 0.144f
+            val eyeVOffset = 36.dp * 0.04f
             // 왼쪽 눈 (흰 테두리)
             Box(
                 modifier = Modifier
-                    .size(eyeSize + 2.dp)
-                    .offset(x = -eyeOffset, y = -eyeSize * 0.3f)
+                    .size(eyeSize + 3.dp)
+                    .offset(x = -eyeHOffset, y = eyeVOffset)
                     .background(Color.White, CircleShape),
                 contentAlignment = Alignment.Center
             ) {
@@ -418,8 +423,8 @@ private fun MoodCell(
             // 오른쪽 눈 (흰 테두리)
             Box(
                 modifier = Modifier
-                    .size(eyeSize + 2.dp)
-                    .offset(x = eyeOffset, y = -eyeSize * 0.3f)
+                    .size(eyeSize + 3.dp)
+                    .offset(x = eyeHOffset, y = eyeVOffset)
                     .background(Color.White, CircleShape),
                 contentAlignment = Alignment.Center
             ) {


### PR DESCRIPTION
## Summary
- AOS#5,#6,#7,#8 한 번에 처리 — iOS `MongleMonggle` / `MongleSceneView` 수치로 정합
- 점프 높이 / 눈 위치 / Mood 화면 / 전체화면 캐릭터 size 모두 일관

## Changes

### 1. `MongleCharacter.kt`
| 위치 | 변경 |
|---|---|
| 3 곳의 `eyeVOffset` | `size * 0.07f` → **`size * 0.04f`** (iOS MongleMonggle 매칭, AOS#6 / #8) |
| `MongleSceneView.charSizePx` | 52dp → **56dp** (iOS MongleMonggle 기본 size) |
| 물리 루프 `delay(120)` | → **`delay(160)`** (iOS interval=0.16s) |
| `tween durationMillis = 110` | → **150** |
| `hopTarget` | `sin(stepCount * π/4.0) * 14` → **`sin(stepCount * π/5.0) * 12`** (iOS 동일) |

### 2. `QuestionDetailScreen.kt` MoodCell (마음남기기)
| 위치 | 변경 |
|---|---|
| 눈 y offset | `-eyeSize * 0.3f` (위로!) → **`size * 0.04f`** (아래로, iOS 동일) |
| 눈 x offset 비율 | `0.14f` → **`0.144f`** |
| 흰 테두리 | `+2.dp` → **`+3.dp`** |

## Root cause 가설
- 점프: AOS 사이클(0.96s) 이 iOS(1.6s) 보다 빨라 perceptual amplitude 가 압축 → "점프가 낮다" 인지
- Mood 화면: 부호 반대로 그려 눈이 위쪽에 위치 (iOS 는 아래쪽)
- 일반 캐릭터: 눈 수직 offset 0.07 vs 0.04 차이로 인상이 다름

## Side effects
- 점프 사이클이 0.96s → 1.6s 로 느려짐 (iOS 패리티 우선)
- `charSizePx` 4dp 증가 → 충돌 반지름 / 벽 패딩 비례 증가, 더 넉넉한 배치
- Mood 화면 캐릭터 디자인 회복 (이전엔 눈이 위로 향한 시각 결함)

## Test plan
- [x] `./gradlew :app:assembleDebug` 성공
- [ ] Home 메인 몽글 캐릭터 눈 위치/크기 iOS 와 동일 확인
- [ ] 점프 애니메이션 — 진폭/주기 iOS 동일
- [ ] 마음남기기(QuestionDetail) 5개 mood cell 눈이 정상 (아래쪽) 위치
- [ ] 멤버 아바타(MongleCharacterAvatar) 눈 위치 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)