### PR TITLE
fix(aos-network): BASE_URL 을 prod stage 로 정합 (MG-117)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,11 @@ android {
         versionName = "1.0.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField("String", "BASE_URL", "\"https://1cq1kfgvf1.execute-api.ap-northeast-2.amazonaws.com/\"")
+        // MG-117 — AOS 가 dev stage(1cq1kfgvf1) 를 가리키고 있어 iOS 의 prod stage 와 완전
+        // 분리된 별도 DB/사용자/가족 그룹을 사용하던 구조 차단. AOS#4("iOS 의 답변/재촉 알림을
+        // 받을 수 없음") 의 직접적 root cause.
+        // (기존 AOS 사용자는 본인 + 소수 테스터로 한정 → 데이터 마이그레이션 없이 강제 재가입.)
+        buildConfigField("String", "BASE_URL", "\"https://15i45fprse.execute-api.ap-northeast-2.amazonaws.com/\"")
         buildConfigField("String", "KAKAO_APP_KEY", "\"73b4d3e9a62701280ec877fe441949b3\"")
         buildConfigField("String", "GOOGLE_WEB_CLIENT_ID", "\"43055125841-in9de5felh4f90rq8vee9lq60uice7uj.apps.googleusercontent.com\"")
         buildConfigField("String", "APPLE_CLIENT_ID", "\"com.mongle.app.signin\"")


### PR DESCRIPTION
## 🚨 Critical — AOS#4 root cause 직접 fix

배포 검증 중 AOS 가 dev stage 를 가리키고 있어 iOS 의 prod stage 와 별도 DB/사용자/가족 그룹을 사용하고 있었음을 발견.

| Stage | Stack | Endpoint | 클라 |
|---|---|---|---|
| prod | `famtree-api-prod` | `15i45fprse...` | iOS ✓ |
| dev | `famtree-api-dev` | `1cq1kfgvf1...` | **AOS (변경 전)** ✗ |

## Changes
- `app/build.gradle.kts:28` BASE_URL: `1cq1kfgvf1` (dev) → **`15i45fprse`** (prod)

## Side effects
- ⚠️ **AOS 기존 사용자(본인 + 소수 테스터)는 첫 실행 시 강제 재가입** — dev DB 의 가족/답변/알림 history 미보존
- AOS 사용자 = 테스터 한정이라 마이그레이션 없이 진행 결정

## 후속 권장
- `serverless remove --stage dev` 로 dev Lambda/DB 폐기 (비용 절감)
- 이미 머지된 다른 PR (MG-111~116) 의 효과는 이번 fix 후 prod 환경에서 비로소 검증 가능

## Test plan
- [x] `./gradlew :app:assembleDebug` 성공
- [ ] 새 빌드 디바이스 설치 → 신규 가입 → prod 가족 생성/참여
- [ ] iOS 디바이스에서 동일 가족 참여 → 양방향 답변/재촉 알림 정상 도착

🤖 Generated with [Claude Code](https://claude.com/claude-code)