### PR TITLE
fix(aos-guest): 둘러보기 게스트 가드 + 로그인 팝업 (MG-119)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
@@ -138,6 +138,8 @@ fun HomeScreen(
     onNavigateToWriteQuestion: () -> Unit,
     onNavigateToGroupSelect: () -> Unit = {},
     onGroupSelected: (java.util.UUID) -> Unit = {},
+    // MG-119 — 게스트 모드 팝업의 "로그인" 버튼 콜백. iOS HomeFeature delegate(.requestLogin) 패리티.
+    onRequestLogin: () -> Unit = {},
     viewModel: HomeViewModel = hiltViewModel(),
     adManager: com.mongle.android.util.AdManager? = null
 ) {
@@ -161,6 +163,8 @@ fun HomeScreen(
     var showNudgeUnavailableDialog by remember { mutableStateOf<String?>(null) }
     var showSkipConfirmDialog by remember { mutableStateOf(false) }
     var showWriteConfirmDialog by remember { mutableStateOf(false) }
+    // MG-119 — 게스트 모드 로그인 유도 팝업.
+    var showGuestLoginPopup by remember { mutableStateOf(false) }
 
     // 화면 복귀 시 답변 상태 새로고침 (앱 백그라운드 → 포그라운드 복귀)
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -202,11 +206,9 @@ fun HomeScreen(
                 is HomeEvent.ShowAnswerFirstToView -> showAnswerFirstDialog = event.memberName
                 is HomeEvent.ShowNudgeUnavailable -> showNudgeUnavailableDialog = event.memberName
                 HomeEvent.ShowGuestLoginRequired -> {
-                    // 게스트 모드 — 로그인 유도 토스트로 안내. iOS MG-50 패리티.
-                    toastData = MongleToastData(
-                        message = "로그인 후 이용할 수 있어요",
-                        type = MongleToastType.ERROR
-                    )
+                    // MG-119 — Toast 단순 안내에서 MonglePopup(로그인 / 취소) 으로 격상.
+                    // iOS HomeFeature.showGuestLoginPrompt 패리티. 로그인 버튼 → 로그인 화면.
+                    showGuestLoginPopup = true
                 }
                 is HomeEvent.ShowError -> {
                     val msg = when {
@@ -461,6 +463,26 @@ fun HomeScreen(
             onDismiss = { peerAnswerData = null },
             characterColor = data.characterColor
         )
+    }
+
+    // MG-119 — 게스트 모드 로그인 유도 팝업. iOS HomeFeature.showGuestLoginPrompt 패리티.
+    if (showGuestLoginPopup) {
+        Dialog(
+            onDismissRequest = { showGuestLoginPopup = false },
+            properties = DialogProperties(usePlatformDefaultWidth = false)
+        ) {
+            MonglePopup(
+                title = stringResource(R.string.guest_login_required_title),
+                description = stringResource(R.string.guest_login_required_desc),
+                primaryLabel = stringResource(R.string.guest_login_required_btn_login),
+                onPrimary = {
+                    showGuestLoginPopup = false
+                    onRequestLogin()
+                },
+                secondaryLabel = stringResource(R.string.common_cancel),
+                onSecondary = { showGuestLoginPopup = false }
+            )
+        }
     }
 
     // 먼저 답변 완료 팝업 (답변 보기 시도)

--- a/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
@@ -230,6 +230,11 @@ class HomeViewModel @Inject constructor(
     }
 
     fun onQuestionTapped() {
+        // MG-119 — 게스트 모드에서 답변 화면 진입 차단 + 로그인 유도 팝업.
+        if (_uiState.value.currentUser == null) {
+            viewModelScope.launch { _events.emit(HomeEvent.ShowGuestLoginRequired) }
+            return
+        }
         val question = _uiState.value.todayQuestion ?: return
         viewModelScope.launch {
             _events.emit(HomeEvent.NavigateToQuestionDetail(question))
@@ -302,7 +307,12 @@ class HomeViewModel @Inject constructor(
 
     fun onMemberTapped(member: User) {
         val state = _uiState.value
-        val currentUser = state.currentUser ?: return
+        // MG-119 — 게스트 모드에서 멤버 탭 시 silent return 대신 로그인 유도.
+        if (state.currentUser == null) {
+            viewModelScope.launch { _events.emit(HomeEvent.ShowGuestLoginRequired) }
+            return
+        }
+        val currentUser = state.currentUser
         if (member.id == currentUser.id) return
 
         viewModelScope.launch {
@@ -322,6 +332,11 @@ class HomeViewModel @Inject constructor(
     }
 
     fun onViewAnswerTapped(member: User) {
+        // MG-119 — 게스트는 가족 답변 조회 불가. 로그인 유도.
+        if (_uiState.value.currentUser == null) {
+            viewModelScope.launch { _events.emit(HomeEvent.ShowGuestLoginRequired) }
+            return
+        }
         viewModelScope.launch {
             val state = _uiState.value
             val memberIndex = state.familyMembers.indexOfFirst { it.id == member.id }
@@ -414,6 +429,11 @@ class HomeViewModel @Inject constructor(
     }
 
     fun skipQuestion() {
+        // MG-119 — 게스트는 질문 다시받기 불가.
+        if (_uiState.value.currentUser == null) {
+            viewModelScope.launch { _events.emit(HomeEvent.ShowGuestLoginRequired) }
+            return
+        }
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
             runCatching { questionRepository.skipQuestion() }
@@ -437,6 +457,11 @@ class HomeViewModel @Inject constructor(
     }
 
     fun watchAdForWrite(adManager: AdManager) {
+        // MG-119 — 게스트는 나만의 질문 작성 불가.
+        if (_uiState.value.currentUser == null) {
+            viewModelScope.launch { _events.emit(HomeEvent.ShowGuestLoginRequired) }
+            return
+        }
         _uiState.update { it.copy(isLoading = true) }
         adManager.showRewardedAd(
             onRewarded = {
@@ -468,6 +493,11 @@ class HomeViewModel @Inject constructor(
     }
 
     fun watchAdForSkip(adManager: AdManager) {
+        // MG-119 — 게스트는 광고/스킵 흐름 불가.
+        if (_uiState.value.currentUser == null) {
+            viewModelScope.launch { _events.emit(HomeEvent.ShowGuestLoginRequired) }
+            return
+        }
         _uiState.update { it.copy(isLoading = true) }
         adManager.showRewardedAd(
             onRewarded = {

--- a/app/src/main/java/com/mongle/android/ui/main/MainTabScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/main/MainTabScreen.kt
@@ -54,6 +54,8 @@ fun MainTabScreen(
     onQuestionSkipped: (Int) -> Unit = {},
     onLogout: () -> Unit = {},
     onGroupLeft: () -> Unit = {},
+    // MG-119 — 게스트 모드에서 로그인 유도 팝업의 "로그인" 버튼 콜백.
+    onRequestLogin: () -> Unit = {},
     answerSubmittedCount: Int = 0,
     adManager: AdManager? = null
 ) {
@@ -146,6 +148,7 @@ fun MainTabScreen(
                     onNavigateToWriteQuestion = onNavigateToWriteQuestion,
                     onNavigateToGroupSelect = onNavigateToGroupSelect,
                     onGroupSelected = onGroupSelected,
+                    onRequestLogin = onRequestLogin,
                     viewModel = homeViewModel,
                     adManager = adManager
                 )

--- a/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
+++ b/app/src/main/java/com/mongle/android/ui/navigation/MongleNavHost.kt
@@ -406,6 +406,8 @@ fun MongleNavHost(
                                 groupLeftToast = true
                                 rootViewModel.onGroupLeft()
                             },
+                            // MG-119 — 게스트 모드 로그인 팝업의 "로그인" 버튼.
+                            onRequestLogin = { rootViewModel.requestLoginFromGuest() },
                             answerSubmittedCount = answerSubmittedCount,
                             adManager = adManager
                         )

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -374,6 +374,20 @@ class RootViewModel @Inject constructor(
         }
     }
 
+    /**
+     * MG-119 — 게스트 모드(currentUser == null) 에서 로그인 필요 액션을 트리거한 뒤
+     * 로그인 팝업의 "로그인" 버튼을 탭한 경우. Unauthenticated 로 전환해 NavHost 가
+     * 로그인 화면을 노출하게 한다. iOS HomeFeature delegate(.requestLogin) 패리티.
+     */
+    fun requestLoginFromGuest() {
+        _uiState.update {
+            RootUiState(
+                appState = AppState.Unauthenticated,
+                currentUser = null
+            )
+        }
+    }
+
     fun onLoggedIn(
         user: User,
         needsConsent: Boolean = false,

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -391,4 +391,9 @@
     <string name="search_yesterday">昨日</string>
     <string name="search_date_pattern">M月d日</string>
     <string name="notif_date_pattern">M月d日</string>
+
+    <!-- MG-119 — ゲスト閲覧モード ログイン要求ポップアップ -->
+    <string name="guest_login_required_title">ログインが必要です</string>
+    <string name="guest_login_required_desc">ログイン後にご利用いただける機能です。ログインしますか？</string>
+    <string name="guest_login_required_btn_login">ログイン</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -391,4 +391,9 @@
     <string name="search_yesterday">어제</string>
     <string name="search_date_pattern">M월 d일</string>
     <string name="notif_date_pattern">M월 d일</string>
+
+    <!-- MG-119 — 둘러보기 게스트 가드 팝업 -->
+    <string name="guest_login_required_title">로그인이 필요해요</string>
+    <string name="guest_login_required_desc">로그인 후 이용할 수 있는 기능이에요. 로그인하시겠어요?</string>
+    <string name="guest_login_required_btn_login">로그인</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -392,4 +392,9 @@
     <string name="search_yesterday">Yesterday</string>
     <string name="search_date_pattern">MMM d</string>
     <string name="notif_date_pattern">M/d</string>
+
+    <!-- MG-119 — 둘러보기 게스트 가드 팝업 -->
+    <string name="guest_login_required_title">Login required</string>
+    <string name="guest_login_required_desc">This feature is only available to logged-in users. Would you like to log in now?</string>
+    <string name="guest_login_required_btn_login">Log in</string>
 </resources>


### PR DESCRIPTION
## Summary
- 둘러보기(currentUser == null) 모드에서 탭바 외 모든 Home 인터랙션에 게스트 가드 + 로그인 유도 팝업
- iOS HomeFeature.showGuestLoginPrompt 패리티

## Changes
**HomeViewModel** — 가드 추가:
| 액션 | 기존 | 변경 |
|---|---|---|
| `onQuestionTapped` | 무가드 | 게스트 → ShowGuestLoginRequired |
| `onMemberTapped` | silent return | 게스트 → ShowGuestLoginRequired |
| `onViewAnswerTapped` | 무가드 | 게스트 → ShowGuestLoginRequired |
| `skipQuestion` | 무가드 | 게스트 → ShowGuestLoginRequired |
| `watchAdForWrite` | 무가드 | 게스트 → ShowGuestLoginRequired |
| `watchAdForSkip` | 무가드 | 게스트 → ShowGuestLoginRequired |

기존 가드(onNudgeTapped / requestNotificationsEntry) 는 그대로 유지.

**UI**:
- `HomeScreen`: `ShowGuestLoginRequired` event → Toast → **MonglePopup** (로그인 / 취소) 으로 격상
- 다국어 strings (ko/en/ja) 추가

**라우팅**:
- `MainTabScreen` → `HomeScreen` 에 `onRequestLogin` 콜백 prop 추가
- `MongleNavHost` → `MainTabScreen` 에 `onRequestLogin = { rootViewModel.requestLoginFromGuest() }` wiring
- `RootViewModel.requestLoginFromGuest()` 신규 — `AppState.Unauthenticated` 로 전환 → 로그인 화면 노출

## 미커버 (follow-up 후보)
- History / Settings 탭 가드 — iOS 도 Home 만 명시적 가드라 패리티 한정
- Home 의 group dropdown / heart callout 등 정보성 UI 는 가드 없이 표시 (비파괴적)

## Test plan
- [x] `./gradlew :app:assembleDebug` 성공
- [ ] 둘러보기 진입 → 오늘의 질문 카드 탭 → 로그인 팝업
- [ ] 멤버 캐릭터 탭 → 로그인 팝업
- [ ] "로그인" 버튼 → 로그인 화면 진입
- [ ] "취소" → 팝업 dismiss + 게스트 모드 유지
- [ ] 정상 로그인 사용자는 무영향 (기존 흐름)

🤖 Generated with [Claude Code](https://claude.com/claude-code)