### PR TITLE
fix(aos-guest): 캐릭터/그룹/Settings 게스트 가드 보강 (MG-120)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
@@ -314,15 +314,19 @@ fun HomeScreen(
                 user?.let { viewModel.onNudgeTapped(it) }
             },
             onSelfTap = {
+                // MG-120 — 게스트 모드는 본인 캐릭터 탭 시 답변/조회 흐름 진입 차단 + 로그인 유도.
+                val me = uiState.currentUser ?: run {
+                    showGuestLoginPopup = true
+                    return@MongleSceneView
+                }
                 // 본인 몽글캐릭터 탭 시: 어떤 상태에서도 무조건 "보이는 동작"이 있어야 한다.
                 // 1) 답변 완료 + 캐시에 본인 답변 있음 → PeerAnswerSheet 즉시 노출
                 // 2) 그 외(답변 전 / 캐시 미스 등) → 오늘의 질문 바텀시트 노출
                 //    (질문 바텀시트는 hasAnswered 일 땐 "답변 수정", 아니면 "답변하기" 버튼을 보여준다)
                 // 과거에는 viewModel.onViewAnswerTapped 의 silent fail 경로(서버 응답 없음 등)
                 // 때문에 탭이 무반응이 되는 회귀가 있었다 — 동기 fallback 으로 차단한다.
-                val me = uiState.currentUser
-                val cachedMyAnswer = me?.let { uiState.memberAnswers[it.id] }
-                if (me != null && uiState.hasAnsweredToday && cachedMyAnswer != null) {
+                val cachedMyAnswer = uiState.memberAnswers[me.id]
+                if (uiState.hasAnsweredToday && cachedMyAnswer != null) {
                     val idx = uiState.familyMembers.indexOfFirst { it.id == me.id }.coerceAtLeast(0)
                     val color = sceneMembers.find { it.id == me.id }?.color
                     peerAnswerData = PeerAnswerDisplay(me, idx, cachedMyAnswer, color)
@@ -348,7 +352,14 @@ fun HomeScreen(
                 hearts = uiState.currentUser?.hearts ?: 0,
                 hasNotification = uiState.hasUnreadNotifications,
                 showGroupDropdown = showGroupDropdown,
-                onGroupDropdownToggle = { showGroupDropdown = !showGroupDropdown },
+                // MG-120 — 게스트 모드는 그룹 dropdown / 그룹 이름 탭 시 로그인 유도.
+                onGroupDropdownToggle = {
+                    if (uiState.currentUser == null) {
+                        showGuestLoginPopup = true
+                    } else {
+                        showGroupDropdown = !showGroupDropdown
+                    }
+                },
                 onTopBarMeasured = { topBarHeightPx = it },
                 onNotificationTap = {
                     // 게스트 모드 가드 — true 일 때만 실제 진입.

--- a/app/src/main/java/com/mongle/android/ui/main/MainTabScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/main/MainTabScreen.kt
@@ -163,7 +163,9 @@ fun MainTabScreen(
                     onLogout = onLogout,
                     onAccountDeleted = onLogout,
                     onGroupLeft = onGroupLeft,
-                    familyId = rootUiState.family?.id
+                    familyId = rootUiState.family?.id,
+                    // MG-120 — 게스트 모드 로그인 팝업의 "로그인" 버튼 콜백.
+                    onRequestLogin = onRequestLogin
                 )
             }
         }

--- a/app/src/main/java/com/mongle/android/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/settings/SettingsScreen.kt
@@ -118,6 +118,8 @@ fun SettingsScreen(
     onAccountDeleted: () -> Unit,
     onGroupLeft: () -> Unit = {},
     familyId: java.util.UUID? = null,
+    // MG-120 — 게스트 모드 로그인 팝업의 "로그인" 버튼 콜백.
+    onRequestLogin: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val rawUiState by viewModel.uiState.collectAsState()
@@ -130,6 +132,18 @@ fun SettingsScreen(
     val context = LocalContext.current
     val navController = rememberNavController()
     var toastData by remember { mutableStateOf<MongleToastData?>(null) }
+    // MG-120 — 게스트 모드 로그인 유도 팝업.
+    var showGuestLoginPopup by remember { mutableStateOf(false) }
+    // 모든 액션을 게스트 가드로 래핑 — currentUser == null 이면 팝업 노출, 아니면 원래 액션 실행.
+    val guarded: (() -> Unit) -> () -> Unit = { action ->
+        {
+            if (uiState.currentUser == null) {
+                showGuestLoginPopup = true
+            } else {
+                action()
+            }
+        }
+    }
 
     LaunchedEffect(currentUser, loginProviderType, familyId) {
         viewModel.initialize(currentUser, loginProviderType)
@@ -184,13 +198,15 @@ fun SettingsScreen(
                 }
                 MyScreen(
                     uiState = uiState,
-                    onProfileEditTapped = {
+                    // MG-120 — 게스트 모드는 모든 행 탭 시 로그인 유도. guarded 래퍼 적용.
+                    onProfileEditTapped = guarded {
                         viewModel.onEditProfileTapped()
                         navController.navigate("profile_edit")
                     },
-                    onNotificationsTapped = { navController.navigate("notifications") },
-                    onGroupManagementTapped = { navController.navigate("group_management") },
-                    onAccountManagementTapped = { navController.navigate("account_management") },
+                    onNotificationsTapped = guarded { navController.navigate("notifications") },
+                    onGroupManagementTapped = guarded { navController.navigate("group_management") },
+                    onAccountManagementTapped = guarded { navController.navigate("account_management") },
+                    // 약관/개인정보/UMP 옵션은 비인증 상태에서도 접근 허용 (법적 의무 / 사용자 권리).
                     onPrivacyOptionsTapped = { act -> viewModel.onPrivacyOptionsTapped(act) }
                 )
             }
@@ -268,6 +284,26 @@ fun SettingsScreen(
             toastData = toastData,
             onDismiss = { toastData = null }
         )
+
+        // MG-120 — 게스트 모드 로그인 유도 팝업 (Home 패턴 동일).
+        if (showGuestLoginPopup) {
+            Dialog(
+                onDismissRequest = { showGuestLoginPopup = false },
+                properties = DialogProperties(usePlatformDefaultWidth = false)
+            ) {
+                MonglePopup(
+                    title = stringResource(R.string.guest_login_required_title),
+                    description = stringResource(R.string.guest_login_required_desc),
+                    primaryLabel = stringResource(R.string.guest_login_required_btn_login),
+                    onPrimary = {
+                        showGuestLoginPopup = false
+                        onRequestLogin()
+                    },
+                    secondaryLabel = stringResource(R.string.common_cancel),
+                    onSecondary = { showGuestLoginPopup = false }
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
MG-119 누락 영역 보강.

## Changes
- **HomeScreen**:  (본인 캐릭터) +  (그룹 이름) 가드
- **SettingsScreen**: 자체 팝업 + `guarded` wrapper 로 ProfileEdit/Notifications/GroupManagement/AccountManagement 모두 가드. 약관/개인정보 행은 비가드 (법적 권리)
- **MainTabScreen**: SettingsScreen 으로 `onRequestLogin` wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)