### PR TITLE
fix(aos-guest): 씬 멤버 onAnswerFirst* 콜백 게스트 가드 (MG-121)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
@@ -334,8 +334,17 @@ fun HomeScreen(
                     showQuestionSheet = true
                 }
             },
-            onAnswerFirstToView = { name -> showAnswerFirstDialog = name },
-            onAnswerFirstToNudge = { name -> showNudgeUnavailableDialog = name },
+            // MG-121 — 게스트 모드는 "먼저 답변하세요" 다이얼로그 대신 로그인 유도 팝업.
+            // canView = hasCurrentUserAnswered || hasCurrentUserSkipped 가 게스트에선 항상 false 라
+            // 다른 멤버 탭 시 항상 onAnswerFirst* 분기로 떨어지던 케이스 차단.
+            onAnswerFirstToView = { name ->
+                if (uiState.currentUser == null) showGuestLoginPopup = true
+                else showAnswerFirstDialog = name
+            },
+            onAnswerFirstToNudge = { name ->
+                if (uiState.currentUser == null) showGuestLoginPopup = true
+                else showNudgeUnavailableDialog = name
+            },
             modifier = Modifier.fillMaxSize()
         )
 


### PR DESCRIPTION
씬에 뛰어다니는 다른 멤버 캐릭터 탭 시 게스트가 "먼저 답변하세요" 다이얼로그를 보던 문제 차단. HomeScreen 람다 내부에서 currentUser == null 검증 후 로그인 팝업으로 라우팅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)