### PR TITLE
fix(aos-fcm): FCM 토큰을 올바른 엔드포인트로 전송 (MG-112)

### DIFF
--- a/app/src/main/java/com/mongle/android/data/remote/ApiUserRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ApiUserRepository.kt
@@ -63,7 +63,10 @@ class ApiUserRepository @Inject constructor(
     }
 
     suspend fun registerFcmToken(token: String) = safeCall {
-        api.registerDeviceToken(RegisterDeviceTokenRequest(token))
+        // 이전엔 registerDeviceToken (PATCH /users/me/device-token, APNs 엔드포인트) 을
+        // 잘못 호출해 서버 users.fcm_token 컬럼이 영구 null 이었음. RootViewModel 의
+        // runCatching swallow 와 결합돼 logcat 흔적도 남지 않아 장기간 잠복. (MG-112)
+        api.registerFcmToken(RegisterDeviceTokenRequest(token))
     }
 
     override suspend fun claimDailyHeart(): DailyHeartResult? = try {

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -262,9 +262,20 @@ class RootViewModel @Inject constructor(
                                     }
                                 }
                         }
+                        // MG-112 — registerFcmToken 결과를 logcat 으로 표면화. 이전엔 outer
+                        // runCatching 이 모든 예외를 swallow 해 잘못된 엔드포인트 호출도 흔적
+                        // 없이 사라졌음. 등록 성공/실패는 디버깅의 핵심 단서이므로 명시 로깅.
                         if (fcmToken != null) {
-                            (userRepository as? com.mongle.android.data.remote.ApiUserRepository)
-                                ?.registerFcmToken(fcmToken)
+                            val repo = userRepository as? com.mongle.android.data.remote.ApiUserRepository
+                            if (repo == null) {
+                                android.util.Log.w("RootVM", "FCM 토큰 등록 skip — userRepository cast 실패")
+                            } else {
+                                runCatching { repo.registerFcmToken(fcmToken) }
+                                    .onSuccess { android.util.Log.d("RootVM", "FCM 토큰 서버 등록 성공") }
+                                    .onFailure { android.util.Log.w("RootVM", "FCM 토큰 서버 등록 실패", it) }
+                            }
+                        } else {
+                            android.util.Log.w("RootVM", "FCM 토큰 미발급 — 서버 등록 skip")
                         }
                     }
 


### PR DESCRIPTION
## Summary
- `ApiUserRepository.registerFcmToken` 이 `MongleApiService.registerFcmToken` 대신 `registerDeviceToken` (APNs 엔드포인트) 을 잘못 호출하던 결함 수정
- 서버 `users.fcm_token` 이 영구 null 로 남아 안드로이드 푸시 전체 미수신의 직접 원인
- 토큰 등록 성공/실패/cast 실패/토큰 미발급을 logcat 으로 표면화 (silent failure 차단)

## 배경 / 진단

서버 DB 직접 검증 결과:
- 최근 24시간 내 활동 사용자 4명 중 `users.fcm_token` 보유자 **0명**
- 본인 테스트 계정(`mrdydgjs@naver.com`) 도 안드로이드 로그인 성공(refreshToken 발급 흔적 존재)에도 `fcm_token` null

코드 추적 결과 `ApiUserRepository.kt:65-67`:

```kotlin
suspend fun registerFcmToken(token: String) = safeCall {
    api.registerDeviceToken(RegisterDeviceTokenRequest(token))   // ← 잘못됨
}
```

`MongleApiService.kt:409-413` 인터페이스 정의는 두 메서드를 명확히 분리:

```kotlin
@PATCH(\"users/me/device-token\")   // 서버는 apns_token 갱신
suspend fun registerDeviceToken(@Body body: RegisterDeviceTokenRequest)

@PATCH(\"users/me/fcm-token\")       // 서버는 fcm_token 갱신
suspend fun registerFcmToken(@Body body: RegisterDeviceTokenRequest)
```

안드로이드 클라이언트의 FCM 토큰이 APNs 등록 엔드포인트로 전송되어 `users.fcm_token` 은 갱신되지 않음. 푸시 발송 로직(`NudgeService` / `AnswerService` / `QuestionService` / `reminderScheduler`) 에서 `fcmToken` null 사용자는 모두 발송 스킵.

## 변경
- `ApiUserRepository.kt:66` — 한 줄 fix (`registerDeviceToken` → `registerFcmToken`)
- `RootViewModel.kt:265-281` — outer `runCatching` 이 swallow 하던 등록 결과를 logcat 으로 표면화
  - 성공: `Log.d(\"RootVM\", \"FCM 토큰 서버 등록 성공\")`
  - 실패: `Log.w(\"RootVM\", \"FCM 토큰 서버 등록 실패\", it)`
  - cast 실패: `Log.w(\"RootVM\", \"FCM 토큰 등록 skip — userRepository cast 실패\")`
  - 토큰 미발급: `Log.w(\"RootVM\", \"FCM 토큰 미발급 — 서버 등록 skip\")`

## 호환성
- 서버 라우트 `PATCH /users/me/fcm-token` 은 이미 운영 (`UserController.ts:90-100`)
- 요청 body 동일 (`{ token: string }`)
- iOS / 서버 / 다른 흐름 영향 없음
- 회귀 가능성 없음

## 빌드 검증
- 작업 환경에 JDK 미설치로 `gradlew compileDebugKotlin` 실행 불가
- 변경은 메서드 호출명 한 글자 + fully-qualified 로깅 추가뿐이라 import 충돌 없음
- 머지 전 Android Studio 에서 빌드 한 번 검증 부탁

## Test plan
- [ ] 본인 계정 안드로이드 재로그인 → DB `users.fcm_token` 채워지는지 확인
- [ ] logcat 에서 `RootVM` 태그로 \"FCM 토큰 서버 등록 성공\" 메시지 확인
- [ ] iOS 또는 서버 스크립트로 재촉 발송 시 안드로이드 트레이 알림 표시 (MG-111 머지 후 종단 검증)
- [ ] 다른 사용자 활동 시 fcmToken 보유 비율 0% → 정상 비율 회복 확인
- [ ] 회귀 — iOS APNs 토큰 등록(별도 흐름) 영향 없음

## 관련 티켓
- 서버 측 페이로드 보강: MG-111 (https://github.com/rrheon/Mongle-Server/pull/59)
- 본 fix 가 머지되어야 MG-111 의 효과가 안드로이드에서 실제로 보임 (둘 다 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)