### PR TITLE
fix(aos-nudge): PeerNudge 토스트 replay 차단 — one-shot 이벤트로 전환 (MG-116)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/nudge/PeerNudgeScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/nudge/PeerNudgeScreen.kt
@@ -84,20 +84,20 @@ fun PeerNudgeScreen(
         )
     }
 
-    // 재촉 전송 성공 시 하트 잔량을 상위에 알리고 토스트 노출
+    // MG-116 — state 기반 LaunchedEffect 가 화면 재진입 시 stale sentCount/errorMessage 를
+    // 다시 읽어 직전 결과 토스트가 replay 되던 회귀를 차단. one-shot SharedFlow 로 일원화.
     val sentToastMessage = stringResource(R.string.nudge_sent)
-    LaunchedEffect(uiState.sentCount) {
-        val heartsRemaining = uiState.heartsRemaining
-        if (uiState.sentCount > 0 && heartsRemaining != null) {
-            onNudgeSent(heartsRemaining)
-            toastData = MongleToastData(message = sentToastMessage, type = MongleToastType.SUCCESS)
-        }
-    }
-
-    LaunchedEffect(uiState.errorMessage) {
-        uiState.errorMessage?.let {
-            toastData = MongleToastData(message = it, type = MongleToastType.ERROR)
-            viewModel.dismissError()
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is PeerNudgeEvent.NudgeSent -> {
+                    onNudgeSent(event.heartsRemaining)
+                    toastData = MongleToastData(message = sentToastMessage, type = MongleToastType.SUCCESS)
+                }
+                is PeerNudgeEvent.Error -> {
+                    toastData = MongleToastData(message = event.message, type = MongleToastType.ERROR)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/mongle/android/ui/nudge/PeerNudgeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/nudge/PeerNudgeViewModel.kt
@@ -7,8 +7,11 @@ import com.mongle.android.data.remote.ApiNudgeRepository
 import com.mongle.android.data.remote.ApiUserRepository
 import com.mongle.android.util.AdManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -19,12 +22,17 @@ data class PeerNudgeUiState(
     val targetUserName: String = "",
     val hearts: Int = 0,
     val isLoading: Boolean = false,
-    val isWatchingAd: Boolean = false,
-    val errorMessage: String? = null,
-    val heartsRemaining: Int? = null,
-    val sentCount: Int = 0
+    val isWatchingAd: Boolean = false
 ) {
     val hasEnoughHearts: Boolean get() = hearts >= 1
+}
+
+// MG-116 — 토스트 트리거를 state(sentCount/errorMessage) 가 아닌 one-shot 이벤트로 발행한다.
+// state 의존 LaunchedEffect 는 화면 재진입 시 stale 값으로 코루틴이 launch 되는 race 가 있어
+// 직전 결과 토스트가 다시 노출되는 회귀를 야기했다. iOS PeerNudgeFeature.Delegate.nudgeSent 패턴 패리티.
+sealed interface PeerNudgeEvent {
+    data class NudgeSent(val heartsRemaining: Int) : PeerNudgeEvent
+    data class Error(val message: String) : PeerNudgeEvent
 }
 
 @HiltViewModel
@@ -36,9 +44,10 @@ class PeerNudgeViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(PeerNudgeUiState())
     val uiState: StateFlow<PeerNudgeUiState> = _uiState.asStateFlow()
 
+    private val _events = MutableSharedFlow<PeerNudgeEvent>()
+    val events: SharedFlow<PeerNudgeEvent> = _events.asSharedFlow()
+
     fun initialize(targetUserId: String, targetUserName: String, hearts: Int) {
-        // 화면 진입 시에는 항상 재촉 전송 관련 상태를 초기화한다.
-        // (sentCount/heartsRemaining 이 남아있으면 재진입 시 토스트가 잘못 노출됨)
         _uiState.update {
             PeerNudgeUiState(
                 targetUserId = targetUserId,
@@ -51,20 +60,15 @@ class PeerNudgeViewModel @Inject constructor(
     fun sendNudge() {
         val state = _uiState.value
         if (state.isLoading || state.targetUserId.isEmpty()) return
-        _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+        _uiState.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             try {
                 val heartsRemaining = nudgeRepository.sendNudge(state.targetUserId)
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        hearts = heartsRemaining,
-                        heartsRemaining = heartsRemaining,
-                        sentCount = it.sentCount + 1
-                    )
-                }
+                _uiState.update { it.copy(isLoading = false, hearts = heartsRemaining) }
+                _events.emit(PeerNudgeEvent.NudgeSent(heartsRemaining))
             } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, errorMessage = AppError.from(e).toastMessage) }
+                _uiState.update { it.copy(isLoading = false) }
+                _events.emit(PeerNudgeEvent.Error(AppError.from(e).toastMessage))
             }
         }
     }
@@ -72,7 +76,7 @@ class PeerNudgeViewModel @Inject constructor(
     fun watchAdForNudge(adManager: AdManager) {
         val state = _uiState.value
         if (state.isWatchingAd) return
-        _uiState.update { it.copy(isWatchingAd = true, errorMessage = null) }
+        _uiState.update { it.copy(isWatchingAd = true) }
         adManager.showRewardedAd(
             onRewarded = {
                 viewModelScope.launch {
@@ -81,15 +85,11 @@ class PeerNudgeViewModel @Inject constructor(
                         val heartsAfterAd = com.mongle.android.data.remote.AdRewardClient.grantAdHearts(userRepository, 1)
                         _uiState.update { it.copy(hearts = heartsAfterAd, isWatchingAd = false) }
                         val heartsRemaining = nudgeRepository.sendNudge(state.targetUserId)
-                        _uiState.update {
-                            it.copy(
-                                hearts = heartsRemaining,
-                                heartsRemaining = heartsRemaining,
-                                sentCount = it.sentCount + 1
-                            )
-                        }
+                        _uiState.update { it.copy(hearts = heartsRemaining) }
+                        _events.emit(PeerNudgeEvent.NudgeSent(heartsRemaining))
                     } catch (e: Exception) {
-                        _uiState.update { it.copy(isWatchingAd = false, errorMessage = AppError.from(e).toastMessage) }
+                        _uiState.update { it.copy(isWatchingAd = false) }
+                        _events.emit(PeerNudgeEvent.Error(AppError.from(e).toastMessage))
                     }
                 }
             },
@@ -97,9 +97,5 @@ class PeerNudgeViewModel @Inject constructor(
                 _uiState.update { it.copy(isWatchingAd = false) }
             }
         )
-    }
-
-    fun dismissError() {
-        _uiState.update { it.copy(errorMessage = null) }
     }
 }


### PR DESCRIPTION
## Summary
- PeerNudge 화면 재진입 시 직전 재촉 결과 토스트가 replay 되던 race 를 차단
- 토스트 트리거를 `sentCount`/`errorMessage` state 의존 → `SharedFlow<PeerNudgeEvent>` one-shot 이벤트 기반으로 전환 (iOS `PeerNudgeFeature.Delegate.nudgeSent` 패턴 패리티)
- `PeerNudgeViewModel` 이 Activity 스코프로 살아남는 NavHost 미사용 구조에서 stale 상태 잔류로 인한 토스트 잘못 노출을 근본 차단

## 원인 (요약)
`MongleNavHost.kt` 가 단일 Composable + `var showNudgeTarget: User?` 토글 패턴으로 PeerNudgeScreen 을 swap → `hiltViewModel()` 의 ViewModelStoreOwner 가 Activity 로 결정 → ViewModel 인스턴스가 화면 unmount 후에도 보존됨. 재진입 시 컴포지션 직후 두 LaunchedEffect 가 모두 enqueue 되는데, `LaunchedEffect(uiState.sentCount)` 의 코루틴이 `LaunchedEffect(targetUser)` 의 `initialize()` 결과 collector resumption 보다 먼저 실행되는 큐 순서가 발생하면 stale `sentCount=1` / `errorMessage` 를 읽어 직전 토스트가 다시 노출됨.

## Test plan
- [ ] 재촉 1회 성공 → 백 → 동일 멤버 캐릭터 단순 클릭으로 PeerNudge 재진입 시 직전 성공 토스트 ("재촉 메시지를 보냈어요!") 재노출 안 됨
- [ ] 재촉 1회 성공 → 백 → 다른 멤버 캐릭터 단순 클릭으로 PeerNudge 재진입 시 직전 토스트 잔존 안 됨
- [ ] 새 진입 화면에서 "재촉하기" 정상 활성, 누르면 새 nudge 수행 — 서버 409/4xx 시 에러 토스트 1회만 노출
- [ ] "광고 보고 재촉하기" 흐름도 동일 — 광고 시청 + grant + nudge 성공 시 한 번만 토스트
- [ ] 게스트 / 하트 부족 / 로딩 가드 등 기존 분기 회귀 없음
- [ ] `:app:compileDebugKotlin` `:app:compileReleaseKotlin` 빌드 성공 (확인 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)