### PR TITLE
chore(aos): gitignore monggle-keystore.txt 변종 매칭

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ local.properties
 *.jks
 *.keystore
 keystore.properties
-monggle-keystore
+monggle-keystore*
 
 # JVM Heap Dumps
 *.hprof


### PR DESCRIPTION
## Summary
- 기존 `.gitignore:18` 의 `monggle-keystore` 라인은 정확한 파일명만 매칭 → `.txt` / `.jks` / `.bak` 등 확장자 변종을 잡지 못함
- `monggle-keystore*` 와일드카드 한 글자 추가로 모든 변종을 무시하도록 일반화
- 검증: `git check-ignore -v app/monggle-keystore.txt` → `.gitignore:18:monggle-keystore* app/monggle-keystore.txt` ✓

## Test plan
- [x] `git check-ignore` 로 monggle-keystore.txt 가 매칭되는 것 확인
- [ ] 기존 monggle-keystore (확장자 없음) 도 여전히 매칭 (회귀 없음 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)