### PR TITLE
fix(aos-notif): indicator 그룹별 게이팅 + 런처 배지 서버 동기화 (MG-117)

### DIFF
--- a/app/src/main/java/com/mongle/android/data/remote/ApiNotificationRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ApiNotificationRepository.kt
@@ -32,6 +32,14 @@ class ApiNotificationRepository @Inject constructor(
         api.getNotifications(limit, familyId).notifications.map { it.toApp() }
     }
 
+    /**
+     * 서버 기준 전 그룹 미읽음 알림 수. 런처 아이콘 배지 / 콜드스타트 동기화 용도.
+     * iOS NotificationRepository.getUnreadCount() 패리티.
+     */
+    suspend fun getUnreadCount(): Int = safeCall {
+        api.getUnreadCount().count
+    }
+
     suspend fun markAsRead(notificationId: String): AppNotification = safeCall {
         api.markNotificationRead(notificationId).toApp()
     }

--- a/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
@@ -317,6 +317,11 @@ data class DeleteAllNotificationsResponse(
     val count: Int
 )
 
+@JsonClass(generateAdapter = true)
+data class UnreadCountResponse(
+    val count: Int
+)
+
 // ── 재촉하기 ──────────────────────────────────────────
 
 @JsonClass(generateAdapter = true)
@@ -483,6 +488,10 @@ interface MongleApiService {
         @Query("limit") limit: Int = 50,
         @Query("group_id") groupId: String? = null
     ): GetNotificationsResponse
+
+    // 미읽음 알림 수 — 런처 배지 / 콜드스타트 동기화에 사용. iOS getUnreadCount 패리티.
+    @GET("notifications/unread-count")
+    suspend fun getUnreadCount(): UnreadCountResponse
 
     @PATCH("notifications/{notificationId}/read")
     suspend fun markNotificationRead(@Path("notificationId") notificationId: String): NotificationDto

--- a/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeViewModel.kt
@@ -129,10 +129,14 @@ class HomeViewModel @Inject constructor(
         checkUnreadNotifications()
     }
 
+    // MG-117 — 홈 종 아이콘 indicator 는 현재 그룹의 미읽음만 반영해야 한다. familyId 인자
+    // 없이 호출하면 다른 그룹 미읽음에도 점이 켜져 그룹 전환 후에도 잔존하는 회귀가 발생.
+    // iOS HomeFeature 의 `notifications.contains { !$0.isRead && $0.familyId == currentFamilyId }` 와 동치.
     private fun checkUnreadNotifications() {
         viewModelScope.launch {
+            val familyId = _uiState.value.family?.id?.toString()
             val hasUnread = runCatching {
-                notificationRepository.getNotifications(limit = 20).any { !it.isRead }
+                notificationRepository.getNotifications(limit = 20, familyId = familyId).any { !it.isRead }
             }.getOrElse { false }
             _uiState.update { it.copy(hasUnreadNotifications = hasUnread) }
         }

--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -303,6 +303,12 @@ class RootViewModel @Inject constructor(
                             errorMessage = if (degraded) lastNetworkError?.message else it.errorMessage
                         )
                     }
+
+                    // MG-117 — 콜드스타트 시 SharedPreferences 의 stale unreadCount 를 서버 기준으로 보정.
+                    // 다른 단말이 mark-as-read 하거나 앱 KILL 동안 새 푸시가 와서 카운트가 어긋난 경우를 정정.
+                    // iOS Root+Reducer.refreshHomeData 직후 setBadgeCount(unreadCountAllGroups) 패리티.
+                    runCatching { notificationRepository.getUnreadCount() }
+                        .onSuccess { unreadBadgeStore.set(it) }
                 }
             } catch (e: Exception) {
                 _uiState.update {
@@ -363,14 +369,19 @@ class RootViewModel @Inject constructor(
         if (type != null) {
             _uiState.update { it.copy(pendingNotificationType = type) }
         }
-        // MG-111 — 트레이 알림 탭 시 서버 알림을 즉시 읽음 처리하고 배지 카운트를 -1.
-        // 알림함 화면 진입 없이 사용자가 푸시만 탭한 케이스에서 unread 가 누적되지 않게 한다.
-        // 실패 시 NotificationViewModel 가 알림함 진입 시 서버 기준으로 재정렬하므로 silent.
+        // MG-111 — 트레이 알림 탭 시 서버 알림을 즉시 읽음 처리.
+        // MG-117 — 읽음 처리 직후 서버 unread-count 로 배지 동기화. SharedPreferences 의
+        // 단순 -1 fallback 은 다중 단말/스토어 누락 시 음수 누적·중복 차감 위험이 있어
+        // 서버 truth 가 우선. 네트워크 실패 시에만 기존 -1 fallback.
         if (notificationId != null) {
             viewModelScope.launch {
                 runCatching { notificationRepository.markAsRead(notificationId) }
-                val current = unreadBadgeStore.get()
-                unreadBadgeStore.set((current - 1).coerceAtLeast(0))
+                runCatching { notificationRepository.getUnreadCount() }
+                    .onSuccess { unreadBadgeStore.set(it) }
+                    .onFailure {
+                        val current = unreadBadgeStore.get()
+                        unreadBadgeStore.set((current - 1).coerceAtLeast(0))
+                    }
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Bug 1** (인앱 indicator): 홈 종 아이콘 빨간 점이 현재 그룹에 미읽음이 0개여도 다른 그룹 미읽음 때문에 켜지던 회귀를 차단. iOS `HomeFeature` 의 `currentFamilyId` 게이팅 1:1 패리티
- **Bug 2** (런처 배지): SharedPreferences 로컬 카운터에만 의존해 콜드스타트 / 다중 단말 환경에서 stale 했던 unread-count 를 서버 엔드포인트와 연결해 보정. iOS `setBadgeCount(unreadCountAllGroups)` 패리티
- 서버에는 이미 `GET /notifications/unread-count` (`NotificationController.ts:60-66`) 가 운영 중 — 클라 미연결 상태였던 것을 연결만 하면 끝

## 변경 내역
- `MongleApiService.kt` — `@GET(\"notifications/unread-count\")` + `UnreadCountResponse` 추가
- `ApiNotificationRepository.kt` — `getUnreadCount(): Int` wrapper
- `HomeViewModel.checkUnreadNotifications` — `getNotifications(familyId = _uiState.value.family?.id?.toString())` per-group 게이팅
- `RootViewModel.loadHomeData` — `AppState.Authenticated` 진입 직후 서버 unread-count 로 `unreadBadgeStore` 보정
- `RootViewModel.handleNotificationTap` — 푸시 탭 후처리에서 `current - 1` 단순 차감 → 서버 `getUnreadCount` 결과로 `set`, 네트워크 실패 시 기존 -1 fallback

## Test plan
- [ ] 그룹 A 미읽음 1, 그룹 B 미읽음 0 → 그룹 B 진입 시 종 아이콘 빨간 점 표시 안 됨
- [ ] 그룹 A 미읽음 1 → 그룹 A 진입 시 점 표시
- [ ] 그룹 전환 시 indicator 가 새 그룹 기준으로 재계산
- [ ] 다른 단말에서 mark-as-read 후 앱 콜드스타트 → 런처 배지가 서버 카운트로 보정
- [ ] 푸시 탭 → 자동 mark-as-read → 다음 푸시 도착 시 배지 카운트 누적 정확
- [ ] 알림 화면 mark-all/delete-all 후 배지 0 으로 동기화 (회귀 없음)
- [x] `:app:compileDebugKotlin` `:app:compileReleaseKotlin` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)