### PR TITLE
fix(aos-home): 본인 답변 시트에 "답변 수정하기" 버튼 추가 (MG-118)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/HomeScreen.kt
@@ -475,13 +475,21 @@ fun HomeScreen(
 
     // PeerAnswerSheet
     peerAnswerData?.let { data ->
+        // MG-118 — 본인 답변 시트일 때 하단 "답변 수정하기" 버튼으로 QuestionDetail 진입.
+        // iOS HomeFeature.myMonggleTapped → PeerAnswer(isMine:true) → editAnswer 패리티.
+        val isMine = uiState.currentUser?.id?.let { it == data.member.id } == true
         PeerAnswerSheet(
             member = data.member,
             memberIndex = data.index,
             questionText = uiState.todayQuestion?.content ?: "",
             answer = data.answer,
             onDismiss = { peerAnswerData = null },
-            characterColor = data.characterColor
+            characterColor = data.characterColor,
+            isMine = isMine,
+            onEdit = {
+                peerAnswerData = null
+                uiState.todayQuestion?.let { onNavigateToQuestionDetail(it) }
+            }
         )
     }
 

--- a/app/src/main/java/com/mongle/android/ui/home/PeerAnswerSheet.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/PeerAnswerSheet.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -53,7 +55,11 @@ fun PeerAnswerSheet(
     questionText: String,
     answer: Answer,
     onDismiss: () -> Unit,
-    characterColor: Color? = null
+    characterColor: Color? = null,
+    // MG-118 — 본인 답변 시트일 때 하단 "답변 수정하기" 버튼 노출.
+    // iOS PeerAnswerFeature.State(isMine: true) + Delegate.editAnswer 패리티.
+    isMine: Boolean = false,
+    onEdit: () -> Unit = {}
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
 
@@ -167,6 +173,25 @@ fun PeerAnswerSheet(
                             text = answer.content,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MongleTextSecondary
+                        )
+                    }
+                }
+
+                // MG-118 — 본인 답변일 때만 "답변 수정하기" 버튼. 탭 시 시트 닫고
+                // QuestionDetailScreen 의 수정 모드(detail_edit_submit) 진입.
+                if (isMine) {
+                    Button(
+                        onClick = onEdit,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp),
+                        shape = RoundedCornerShape(14.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = MonglePrimary)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.sheet_answer_edit),
+                            style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+                            color = Color.White
                         )
                     }
                 }


### PR DESCRIPTION
## Summary
- 홈에서 본인 캐릭터를 탭하면 `PeerAnswerSheet` 가 답변과 함께 노출되지만 iOS 와 달리 답변 수정 진입 버튼이 없어 `QuestionDetailScreen` 의 수정 모드에 도달할 경로가 막혀 있던 회귀 차단
- `PeerAnswerSheet` 에 `isMine: Boolean` / `onEdit: () -> Unit` 파라미터 추가, `isMine == true` 일 때 하단에 기존 string `R.string.sheet_answer_edit` ("답변 수정하기") 버튼 노출
- `HomeScreen` 의 호출부에서 `currentUser.id == data.member.id` 로 `isMine` 결정, 탭 시 시트 닫고 `onNavigateToQuestionDetail(todayQuestion)` 호출
- `QuestionDetailScreen` 은 `hasMyAnswer == true` 일 때 이미 수정 모드(`detail_edit_submit`) 로 동작하므로 별도 화면 신설 불필요

## iOS 패리티
`HomeFeature.myMonggleTapped` → `Delegate.navigateToMyAnswer` → `PeerAnswerFeature.State(isMine: true)` 모달 → "수정하기" 버튼 → `Delegate.editAnswer` → `QuestionDetailFeature` push

## Test plan
- [ ] 본인 답변 완료 상태에서 자기 캐릭터 탭 → 시트 하단에 "답변 수정하기" 버튼 노출
- [ ] 버튼 탭 → 시트 닫힘 + `QuestionDetailScreen` 진입 + "답변 수정하기" 모드 활성
- [ ] 다른 멤버 답변 시트는 버튼 미노출 (회귀 없음)
- [ ] 본인 미답변 → 기존대로 `QuestionSheetBottomSheet` 노출 (회귀 없음)
- [x] `:app:compileDebugKotlin` `:app:compileReleaseKotlin` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)