### PR TITLE
fix(aos-home): 본인 캐릭터 이름에 (나) 마커 추가 (MG-119)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/common/MongleCharacter.kt
+++ b/app/src/main/java/com/mongle/android/ui/common/MongleCharacter.kt
@@ -37,9 +37,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mongle.android.domain.model.User
+import com.ycompany.Monggle.R
 import com.mongle.android.ui.theme.MongleAccentOrange
 import com.mongle.android.ui.theme.MongleMonggleBlue
 import com.mongle.android.ui.theme.MongleMonggleGreenLight
@@ -729,8 +731,15 @@ private fun SceneMongleItem(
         }
 
         Spacer(modifier = Modifier.height(4.dp))
+        // MG-119 — 본인 캐릭터는 이름 옆에 "(나)" suffix 를 붙여 status badge 색상에
+        // 더해 즉시 식별 가능하게 한다. 게스트(currentUserId == null)는 isCurrentUser=false 로 마커 없음.
+        val displayName = if (isCurrentUser) {
+            "$name ${stringResource(R.string.home_member_me_suffix)}"
+        } else {
+            name
+        }
         Text(
-            text = name,
+            text = displayName,
             style = MaterialTheme.typography.labelSmall.copy(
                 fontWeight = FontWeight.Medium,
                 fontSize = 11.sp

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -76,6 +76,8 @@
 
     <!-- Home -->
     <string name="home_default_group">モングル</string>
+    <!-- 自分のキャラクター名の横に付くマーカー (MG-119) -->
+    <string name="home_member_me_suffix">(私)</string>
     <string name="home_today_question">今日の質問</string>
     <string name="home_question_placeholder">午前11時に新しい質問が届きます</string>
     <string name="home_answer_complete">回答済み</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -76,6 +76,8 @@
 
     <!-- Home -->
     <string name="home_default_group">몽글</string>
+    <!-- 본인 캐릭터 이름 옆에 붙는 마커 (MG-119) -->
+    <string name="home_member_me_suffix">(나)</string>
     <string name="home_today_question">오늘의 질문</string>
     <string name="home_question_placeholder">오전 11시에 새로운 질문이 도착해요</string>
     <string name="home_answer_complete">답변 완료</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,8 @@
 
     <!-- Home -->
     <string name="home_default_group">Mongle</string>
+    <!-- Suffix appended to own character name on group home (MG-119) -->
+    <string name="home_member_me_suffix">(me)</string>
     <string name="home_today_question">Today\'s Question</string>
     <string name="home_question_placeholder">A new question arrives at 11 AM</string>
     <string name="home_answer_complete">Answered</string>


### PR DESCRIPTION
## Summary
- 그룹 홈 씬에서 본인 캐릭터의 이름 라벨 옆에 "(나)" suffix 추가 — status badge 색상만으로는 답변 완료 상태에서 본인/타인 구분이 약했던 문제 보완
- 한국어 "(나)" / 영어 "(me)" / 일본어 "(私)" 3 로케일 string resource 추가
- 게스트 모드(`currentUserId == null`)는 `isCurrentUser=false` 분기로 마커 미노출 — 회귀 없음

## 변경 내역
- `MongleCharacter.kt:732` — `SceneMongleItem` 의 name `Text` 에 `isCurrentUser` 분기로 suffix 추가
- `values/strings.xml`, `values-ko/strings.xml`, `values-ja/strings.xml` — `home_member_me_suffix` 키 신규
- import 정리 — `stringResource`, `R` 추가

## iOS
별도 티켓 (MG-120) 으로 동일 변경 적용 예정.

## Test plan
- [ ] 본인 캐릭터 이름이 `이름 (나)` 형태로 표시
- [ ] 다른 멤버 이름은 그대로 (회귀 없음)
- [ ] 게스트 모드 진입 시 어떤 캐릭터에도 (나) 마커 없음
- [ ] 영어/일본어 로케일에서도 적절한 suffix 표시
- [x] `:app:compileDebugKotlin` `:app:compileReleaseKotlin` BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)