### PR TITLE
fix(aos-color): primary 색상을 iOS 파스텔톤으로 동기화 (MG-121)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/theme/Color.kt
+++ b/app/src/main/java/com/mongle/android/ui/theme/Color.kt
@@ -2,17 +2,17 @@ package com.mongle.android.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-// MARK: - Primary (iOS 기준: #4CAF50 계열)
-val MonglePrimary = Color(0xFF4CAF50)
-val MonglePrimaryDark = Color(0xFF388E3C)
-val MonglePrimaryLight = Color(0xFFA5D6A7)
-val MonglePrimaryLightDark = Color(0xFFC2E8D4)
-val MonglePrimaryDarker = Color(0xFF43A047)
-val MonglePrimaryDarkerDark = Color(0xFF6BBF93)
-val MonglePrimarySoft = Color(0xFF43A047)
-val MonglePrimarySoftDark = Color(0xFF6BBF93)
-val MonglePrimaryGradientStart = Color(0xFF6BBF93)
-val MonglePrimaryGradientEnd = Color(0xFF7BC8A0)
+// MARK: - Primary (iOS DesignSystem.swift / xcassets 파스텔톤 기준 — MG-121)
+val MonglePrimary = Color(0xFF8FD5A6)            // iOS primary
+val MonglePrimaryDark = Color(0xFF5BAF85)        // iOS primaryDark — 다크 테마 primary
+val MonglePrimaryLight = Color(0xFFA5D6A7)       // iOS primaryLight
+val MonglePrimaryLightDark = Color(0xFFC2E8D4)   // iOS primaryXLight — 다크 테마 primaryContainer
+val MonglePrimaryDarker = Color(0xFF5BAF85)      // iOS primaryMuted — onPrimaryContainer 가독 contrast
+val MonglePrimaryDarkerDark = Color(0xFF6BBF93)  // iOS primarySoft — 다크 테마 onPrimaryContainer
+val MonglePrimarySoft = Color(0xFF6BBF93)        // iOS primarySoft
+val MonglePrimarySoftDark = Color(0xFF6BBF93)    // iOS primarySoft (light/dark 동일)
+val MonglePrimaryGradientStart = Color(0xFF8FD5A6) // iOS gradientStart
+val MonglePrimaryGradientEnd = Color(0xFFA5E0C0)   // iOS gradientEnd
 val MonglePrimaryXLight = Color(0xFFC2E8D4)
 val MonglePrimaryMuted = Color(0xFF5BAF85)
 val MonglePrimaryDeep = Color(0xFF2E7D32)
@@ -74,10 +74,10 @@ val MongleTextSecondary = Color(0xFF6D6D6D)
 val MongleTextHint = Color(0xFF9E9E9E)
 val MongleTextOnPrimary = Color(0xFFFFFFFF)
 
-// MARK: - Status (iOS 기준: success = #4CAF50)
+// MARK: - Status (iOS 기준: success = #8FD5A6 파스텔 — MG-121)
 val MongleError = Color(0xFFF44336)
 val MongleWarning = Color(0xFFFF9800)
-val MongleSuccessLight = Color(0xFF4CAF50)
+val MongleSuccessLight = Color(0xFF8FD5A6)       // iOS success
 val MongleSuccessDark = Color(0xFF66BB6A)
 val MongleInfo = Color(0xFF42A5F5)
 val MongleNotificationDot = Color(0xFFF44336)

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,5 +7,6 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="mongle_primary">#FF4CAF50</color>
+    <!-- iOS primary 파스텔톤 (#8FD5A6) — MG-121. FCM 알림 colorize 에 사용. -->
+    <color name="mongle_primary">#FF8FD5A6</color>
 </resources>


### PR DESCRIPTION
## Summary
- Material Design saturated green (#4CAF50 / #388E3C / #43A047 / #7BC8A0) 계열로 정의되어 있던 brand primary 색상을 iOS DesignSystem.swift / xcassets 의 파스텔 hex 로 정합
- 변수 이름 / Theme.kt colorScheme 매핑은 그대로 — 호출부 코드 변경 없음
- 이미 iOS 파스텔 hex 와 일치하던 PrimaryLight/LightDark/SoftDark/DarkerDark/Muted/Deep/MonggleGreenLight 는 변경 없음

## 변경 매핑

### `app/src/main/java/com/mongle/android/ui/theme/Color.kt`

| 변수 | 현재 | 변경 후 | iOS 토큰 |
|---|---|---|---|
| `MonglePrimary` | `#4CAF50` | `#8FD5A6` | primary |
| `MonglePrimaryDark` | `#388E3C` | `#5BAF85` | primaryDark |
| `MonglePrimaryDarker` | `#43A047` | `#5BAF85` | primaryMuted |
| `MonglePrimarySoft` | `#43A047` | `#6BBF93` | primarySoft |
| `MonglePrimaryGradientStart` | `#6BBF93` | `#8FD5A6` | gradientStart |
| `MonglePrimaryGradientEnd` | `#7BC8A0` | `#A5E0C0` | gradientEnd |
| `MongleSuccessLight` | `#4CAF50` | `#8FD5A6` | success |

### `app/src/main/res/values/colors.xml`

| 색상 | 현재 | 변경 후 | 비고 |
|---|---|---|---|
| `mongle_primary` | `#FF4CAF50` | `#FF8FD5A6` | FCM 알림 colorize |

## Test plan
- [ ] 홈 / 알림 / 그룹선택 / 설정 등 primary 색상 사용 화면이 진한 녹색 → 파스텔 녹색
- [ ] 그라디언트 배경 (primaryGradientStart→End) 부드러운 파스텔 그라디언트
- [ ] FCM 푸시 도착 시 알림 아이콘 컬러라이즈가 파스텔
- [ ] 다크 테마 진입 시에도 파스텔 톤 유지 (이미 정렬된 light 변형들과 정합)
- [ ] success/checkmark indicator 등 답변 완료 색상이 파스텔
- [ ] orange / heart red / mood 색상 등 다른 토큰 회귀 없음
- [x] `:app:compileDebugKotlin` `:app:compileReleaseKotlin` `:app:processDebugResources` `:app:processReleaseResources` BUILD SUCCESSFUL

## iOS
iOS 는 이미 정답 (DesignSystem.swift / xcassets 가 source of truth) — 별도 작업 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)