### PR TITLE
fix(aos-ui): 몽글 캐릭터 눈 사이즈 홈/그룹선택 0.16 통일 (MG-122)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/common/MongleCharacter.kt
+++ b/app/src/main/java/com/mongle/android/ui/common/MongleCharacter.kt
@@ -556,8 +556,8 @@ private fun SceneMongleItem(
     hasCurrentUserSkipped: Boolean = false
 ) {
     val size = 52.dp
-    // MG-122 — 눈(흰 테두리 + 검은 동공) 비례 축소: 0.18 → 0.14 (22% 감소).
-    val eyeSize = size * 0.14f
+    // MG-122 — 눈(흰 테두리 + 검은 동공) 비례 0.16 — 홈/그룹선택 통일.
+    val eyeSize = size * 0.16f
     val eyeHOffset = size * 0.144f
     // MG-115 — iOS MongleMonggle 의 eyeOffset = size * 0.04 와 일치 (0.07f → 0.04f).
     val eyeVOffset = size * 0.04f

--- a/app/src/main/java/com/mongle/android/ui/groupselect/GroupSelectScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/groupselect/GroupSelectScreen.kt
@@ -314,7 +314,8 @@ fun GroupSelectScreen(
 
 @Composable
 private fun MongleMonggleCircle(color: Color, size: Dp, modifier: Modifier = Modifier) {
-    val eyeSize = size * 0.18f
+    // MG-122 — 눈(흰 테두리 + 검은 동공) 비례 0.16 — 홈/그룹선택 통일.
+    val eyeSize = size * 0.16f
     val eyeOffset = size * 0.14f
     Box(
         modifier = modifier


### PR DESCRIPTION
## Summary

- 홈 `SceneMongleItem` (0.14) 와 그룹선택 `MongleMonggleCircle` (0.18) 의 눈 비율이 서로 달라 같은 캐릭터가 두 화면에서 다르게 보이던 회귀 정정
- MG-122 (이전 PR #56) 의 0.18 → 0.14 축소가 다소 작다는 후속 사용자 피드백 반영해 **0.16 으로 절충**
- 다른 캐릭터 사용처 (PeerAnswerSheet / PeerNudgeScreen / SearchScreen / QuestionDetailScreen / HistoryScreen / OnboardingScreen) 는 의도적으로 0.14 유지

## 변경 위치

| 파일 | Before | After |
| --- | --- | --- |
| `MongleCharacter.kt:560` (`SceneMongleItem`) | `size * 0.14f` | `size * 0.16f` |
| `GroupSelectScreen.kt:317` (`MongleMonggleCircle`) | `size * 0.18f` | `size * 0.16f` |

흰 테두리 두께 (`eyeSize + 2.dp`) 는 그대로 — 비율 자체만 조정.

## Jira

[MG-122](https://ycompany.atlassian.net/browse/MG-122)

## Test plan

- [ ] 홈 씬: 본인/멤버 캐릭터의 눈이 0.14 대비 살짝 커진 상태로 노출
- [ ] 그룹선택 카드 (`OverlappingMonggleRow`): 작은 캐릭터 눈이 0.18 대비 살짝 작아진 상태로 노출
- [ ] 두 화면을 번갈아 보았을 때 같은 캐릭터 표정으로 인식 가능 (눈 비율 동일)
- [ ] PeerAnswer / Nudge / Search / QuestionDetail / History / Onboarding 캐릭터 회귀 없음 (0.14 유지)
- [ ] 라이트/다크 테마 모두 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)