### PR TITLE
fix(aos-ui): CopyPillButton 텍스트/아이콘 White → Black (MG-123)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/groupselect/GroupSelectScreen.kt
+++ b/app/src/main/java/com/mongle/android/ui/groupselect/GroupSelectScreen.kt
@@ -1236,16 +1236,17 @@ private fun CopyPillButton(isCopied: Boolean, onClick: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
+        // MG-123 — pill 배경(파스텔 그린)과의 contrast 확보. 흰 텍스트/아이콘은 시인성 부족.
         Icon(
             imageVector = if (isCopied) Icons.Default.Check else Icons.Default.ContentCopy,
             contentDescription = null,
-            tint = Color.White,
+            tint = Color.Black,
             modifier = Modifier.size(14.dp)
         )
         Text(
             text = if (isCopied) stringResource(R.string.common_copied) else stringResource(R.string.common_copy),
             style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.SemiBold),
-            color = Color.White
+            color = Color.Black
         )
     }
 }


### PR DESCRIPTION
## Summary

- 새 공간 만들기 직후 CREATED 화면의 초대 코드/링크 옆 `CopyPillButton` 이 파스텔 그린 배경에 흰 텍스트/아이콘이라 contrast 부족
- "복사" pill 의 텍스트와 아이콘을 모두 검정으로 변경해 시인성 확보 (한 시각 단위라 통일)
- pill 내부만 수정 — 다른 White 텍스트 (Share 버튼 등) 영향 없음

## 변경 위치

`GroupSelectScreen.kt:1229-1251` `CopyPillButton`

| 요소 | Before | After |
| --- | --- | --- |
| Icon `tint` | `Color.White` | `Color.Black` |
| Text `color` | `Color.White` | `Color.Black` |

## Jira

[MG-123](https://ycompany.atlassian.net/browse/MG-123)

## Test plan

- [ ] 새 공간 생성 직후 CREATED 화면의 "복사" pill 텍스트/아이콘이 검정으로 또렷하게 표시
- [ ] "복사" 탭 후 "복사됨" 상태(아이콘=Check) 도 검정 유지 (배경 alpha 0.8 그린)
- [ ] 초대 코드 row + 초대 링크 row 두 pill 모두 동일 적용
- [ ] 다크 테마에서 진입 시 가독성 회귀 없음
- [ ] Share 버튼·다른 화면의 흰 텍스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)