### PR TITLE
fix(aos-ui): 홈 PeerAnswerSheet 답변 수정 버튼이 탭바에 가려지는 문제

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/home/PeerAnswerSheet.kt
+++ b/app/src/main/java/com/mongle/android/ui/home/PeerAnswerSheet.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -61,7 +62,8 @@ fun PeerAnswerSheet(
     isMine: Boolean = false,
     onEdit: () -> Unit = {}
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    // partial 펼침 상태에서 isMine "답변 수정" 버튼이 탭바/navigation bar 에 가림.
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -73,6 +75,7 @@ fun PeerAnswerSheet(
                 .fillMaxWidth()
                 .verticalScroll(rememberScrollState())
                 .padding(bottom = MongleSpacing.xl)
+                .navigationBarsPadding()
         ) {
             // 헤더 (닫기 버튼)
             Row(


### PR DESCRIPTION
- skipPartiallyExpanded = true: 시트 fully expanded 강제. partial 상태에서 isMine "답변 수정하기" 버튼이 BottomNavigation 과 겹쳐 가려지는 회귀 차단. QuestionSheetBottomSheet 와 동작 패리티.
- navigationBarsPadding(): 콘텐츠 하단에 시스템 navigation bar inset 만큼 여백 확보. 제스처바/3-button 어떤 환경에서도 버튼 잘림 방지.