### PR TITLE
fix(aos-push): FCM payload 의 notificationCount 를 source-of-truth 로 사용 (MG-130)

### DIFF
--- a/app/src/main/java/com/mongle/android/data/local/UnreadBadgeStore.kt
+++ b/app/src/main/java/com/mongle/android/data/local/UnreadBadgeStore.kt
@@ -15,8 +15,9 @@ private const val KEY_UNREAD = "unread_count"
  * 숫자를 그린다. 이 store 는 FCM Service / NotificationViewModel / RootViewModel 사이에서
  * 공유되어 push 도착·mark-read·로그아웃 시점에 배지 숫자를 일관되게 동기화한다.
  *
- * 서버 unread-count API 도입 전까지는 클라 push 카운터로만 동작하며,
- * NotificationViewModel 가 알림 목록을 로드할 때 서버 기준 unread 수로 재정렬된다.
+ * MG-130 부터 서버 push 페이로드의 notificationCount 가 source-of-truth — FCM 수신 시
+ * set(serverCount) 로 동기화. 서버 미전송 시 incrementAndGet() 로 fallback. 알림 목록
+ * 로드 시점에는 NotificationViewModel 이 서버 기준 unread 수로 한 번 더 보정한다.
  */
 @Singleton
 class UnreadBadgeStore @Inject constructor(

--- a/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
+++ b/app/src/main/java/com/mongle/android/fcm/MongleFcmService.kt
@@ -50,15 +50,25 @@ class MongleFcmService : FirebaseMessagingService() {
         // 서버(MG-111)가 페이로드에 notificationId 를 실어 보낸다 — PendingIntent 로 전달해
         // 사용자가 트레이 알림을 탭한 시점에 자동 markAsRead 하기 위함.
         val notificationId = message.data["notificationId"]
+        // 서버(MG-130)가 보낸 unread 합계 — 클라 자체 increment 대신 source-of-truth 로 사용.
+        // 다른 기기에서 읽음 처리되거나 서버에서 알림이 만료(14일 TTL) 되어도 정확히 반영.
+        // 서버 미전송(legacy 서버) 시 incrementAndGet() 로 fallback.
+        val serverUnread = message.data["notificationCount"]?.toIntOrNull()
 
         // iOS MG-55 패리티 — 로그인/온보딩/약관 도중에는 트레이 배너로 흐름을 끊지 않는다.
-        // unread 카운터는 그대로 증가시켜 사용자가 인증 후 알림 화면에서 누적 확인 가능.
+        // unread 카운터는 갱신해 사용자가 인증 후 알림 화면에서 누적 확인 가능.
         if (appForegroundTracker.isInAuthFlow()) {
-            unreadBadgeStore.incrementAndGet()
+            if (serverUnread != null) unreadBadgeStore.set(serverUnread)
+            else unreadBadgeStore.incrementAndGet()
             return
         }
 
-        val unread = unreadBadgeStore.incrementAndGet()
+        val unread = if (serverUnread != null) {
+            unreadBadgeStore.set(serverUnread)
+            serverUnread
+        } else {
+            unreadBadgeStore.incrementAndGet()
+        }
         showNotification(title, body, type, unread, notificationId)
     }
 


### PR DESCRIPTION
## Summary
- `MongleFcmService.onMessageReceived` 가 `message.data[\"notificationCount\"]` (서버 MG-130) 를 우선 파싱해 `unreadBadgeStore.set(serverCount)` 로 동기화
- auth flow 중 / 트레이 알림 빌드 양쪽 경로 모두 적용
- 서버 미전송(legacy) 시 기존 `incrementAndGet()` fallback 유지 — 서버 배포보다 클라 새 버전이 먼저 도달해도 회귀 없음
- `UnreadBadgeStore` doc 주석을 \"서버 페이로드 source-of-truth\" 로 갱신

## 원인
Push 수신마다 클라가 자체 카운트하던 방식은 다른 기기에서 읽음 처리되거나 서버 14일 TTL 만료 시 런처 배지가 실제 unread 와 어긋남.

서버 측 변경: rrheon/Mongle-Server PR (MG-130).

## Test plan
- [ ] 서버 MG-130 dev 배포 완료 후, 푸시 수신 시 런처 배지가 서버 unread 와 일치
- [ ] 다른 기기에서 알림 읽음 처리 → 본 기기 다음 푸시 수신 시 배지 자동 보정
- [ ] legacy (notificationCount 없는 페이로드) 시뮬레이션 → incrementAndGet 동작 유지 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)