### PR TITLE
feat(aos-ad): 서버 /config 기반 광고 토글 (MG-132)

### DIFF
--- a/app/src/main/java/com/mongle/android/MainActivity.kt
+++ b/app/src/main/java/com/mongle/android/MainActivity.kt
@@ -6,12 +6,15 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.mongle.android.data.remote.ConfigRepository
 import com.mongle.android.ui.navigation.MongleNavHost
 import com.mongle.android.ui.root.RootViewModel
 import com.mongle.android.ui.theme.MongleTheme
 import com.mongle.android.util.AdManager
 import com.mongle.android.util.ConsentManager
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -25,10 +28,17 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var consentManager: ConsentManager
 
+    @Inject
+    lateinit var configRepository: ConfigRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         adManager.setActivity(this)
+        // 서버 /config (MG-132) — 광고 토글 캐시 갱신. 동의 흐름보다 먼저 시작해
+        // 다음 부팅부터는 최신값으로 ConsentManager / AdBannerSection 분기가 동작.
+        // 실패는 silent — AdConfigStore 의 기본값(true) 또는 직전 캐시 유지.
+        lifecycleScope.launch { configRepository.refresh() }
         // GDPR/CCPA 동의 흐름(UMP). KR·JP 는 건너뛰고 즉시 AdMob 초기화,
         // 그 외 지역은 동의 폼 표시 후 AdMob 초기화한다.
         consentManager.gatherConsent(this)

--- a/app/src/main/java/com/mongle/android/data/local/AdConfigStore.kt
+++ b/app/src/main/java/com/mongle/android/data/local/AdConfigStore.kt
@@ -1,0 +1,45 @@
+package com.mongle.android.data.local
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val PREFS_NAME = "mongle_ad_config"
+private const val KEY_IS_AD_ENABLED = "is_ad_enabled"
+
+/**
+ * 서버 /config 응답을 캐시하는 source-of-truth (MG-132).
+ *
+ * 부팅 시 ConfigRepository 가 서버에서 최신값을 받아 [set] 으로 갱신한다.
+ * AdBannerSection 과 ConsentManager 는 [isAdEnabled] 를 읽어 광고 렌더링 / AdMob
+ * 초기화 여부를 결정.
+ *
+ * 기본값은 true (광고 표시) — 첫 부팅 / 네트워크 실패 시 운영 사고 없이 기존 동작 유지.
+ * 운영자가 서버 환경변수 ADS_ENABLED=false 로 OFF 한 뒤 다음 부팅부터 반영된다.
+ */
+@Singleton
+class AdConfigStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val prefs by lazy {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    val isAdEnabled: Boolean
+        get() = prefs.getBoolean(KEY_IS_AD_ENABLED, true)
+
+    fun set(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_IS_AD_ENABLED, enabled).apply()
+    }
+
+    companion object {
+        /**
+         * Composable 등 Hilt 주입이 어려운 곳에서 Context 만으로 읽기 위한 정적 진입점.
+         * 인스턴스의 [isAdEnabled] 와 같은 SharedPrefs 를 본다.
+         */
+        fun read(context: Context): Boolean =
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getBoolean(KEY_IS_AD_ENABLED, true)
+    }
+}

--- a/app/src/main/java/com/mongle/android/data/remote/ConfigRepository.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/ConfigRepository.kt
@@ -1,0 +1,23 @@
+package com.mongle.android.data.remote
+
+import com.mongle.android.data.local.AdConfigStore
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * 서버 /config 호출 + AdConfigStore 갱신 (MG-132).
+ *
+ * 앱 부팅 시 1회 호출. 네트워크 실패 시 silent — 다음 부팅 또는 다음 호출에서 다시 시도.
+ * 광고 토글은 즉시성보다 안전한 기본값(=현재 캐시 유지)이 우선.
+ */
+@Singleton
+class ConfigRepository @Inject constructor(
+    private val api: MongleApiService,
+    private val adConfigStore: AdConfigStore
+) {
+    suspend fun refresh(): Result<Boolean> = runCatching {
+        val response = api.getConfig()
+        adConfigStore.set(response.isAdEnabled)
+        response.isAdEnabled
+    }
+}

--- a/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
+++ b/app/src/main/java/com/mongle/android/data/remote/MongleApiService.kt
@@ -508,4 +508,13 @@ interface MongleApiService {
     suspend fun deleteAllNotifications(
         @Query("group_id") groupId: String? = null
     ): DeleteAllNotificationsResponse
+
+    // 클라이언트 광고 노출 토글 (MG-132 / 서버 MG-131). 인증 불필요 — 부팅 시 1회 호출.
+    @GET("config")
+    suspend fun getConfig(): ApiConfigResponse
 }
+
+@JsonClass(generateAdapter = true)
+data class ApiConfigResponse(
+    val isAdEnabled: Boolean
+)

--- a/app/src/main/java/com/mongle/android/ui/common/AdBannerView.kt
+++ b/app/src/main/java/com/mongle/android/ui/common/AdBannerView.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.google.android.gms.ads.AdListener
@@ -17,12 +18,16 @@ import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.LoadAdError
+import com.mongle.android.data.local.AdConfigStore
 
 private const val TAG = "AdBanner"
 private val BANNER_AD_UNIT_ID = BuildConfig.ADMOB_BANNER_ID
 
 @Composable
 fun AdBannerSection(modifier: Modifier = Modifier) {
+    // 서버 /config (MG-132) — 비활성 시 layout 공간도 차지하지 않도록 composable 자체를
+    // no-op 처리. 호출자 (Settings/GroupSelect/Search) 의 분기 코드는 불필요.
+    if (!AdConfigStore.read(LocalContext.current)) return
     Box(
         modifier = modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/mongle/android/util/ConsentManager.kt
+++ b/app/src/main/java/com/mongle/android/util/ConsentManager.kt
@@ -6,6 +6,7 @@ import com.google.android.ump.ConsentDebugSettings
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
+import com.mongle.android.data.local.AdConfigStore
 import com.ycompany.Monggle.BuildConfig
 import java.util.Locale
 import javax.inject.Inject
@@ -24,7 +25,8 @@ import javax.inject.Singleton
  */
 @Singleton
 class ConsentManager @Inject constructor(
-    private val adManager: AdManager
+    private val adManager: AdManager,
+    private val adConfigStore: AdConfigStore
 ) {
     companion object {
         /** UMP 동의 흐름을 건너뛰는 지역(ISO 3166-1 alpha-2). */
@@ -60,6 +62,12 @@ class ConsentManager @Inject constructor(
      * 동의 거부/오류 상황에서도 AdMob 은 반드시 초기화한다 (UMP 가 비개인화 광고로 자동 전환).
      */
     fun gatherConsent(activity: Activity) {
+        // 서버 /config (MG-132) — 광고 OFF 일 때 UMP 동의 흐름과 AdMob 초기화 모두 건너뛴다.
+        // SDK 가 로드되지 않으므로 메모리/네트워크 풋프린트도 함께 절약.
+        if (!adConfigStore.isAdEnabled) {
+            Log.d(TAG, "광고 비활성 (서버 설정) — UMP / AdMob 초기화 건너뜀")
+            return
+        }
         // DEBUG 빌드에서 디버그 지역 시뮬레이션이 활성화된 경우, KR/JP 면제 로직을 건너뛴다.
         val debugActive = BuildConfig.DEBUG && DEBUG_GEOGRAPHY_ENABLED
         if (!debugActive && isExemptedRegion()) {


### PR DESCRIPTION
## Summary
- GET /config (서버 MG-131) → { isAdEnabled: Boolean }
- 부팅 시 ConfigRepository.refresh() 가 호출해 AdConfigStore (SharedPrefs) 캐시 갱신
- ConsentManager.gatherConsent(): isAdEnabled=false 면 UMP / AdMob 초기화 모두 건너뜀 → SDK 미로드로 메모리·네트워크 풋프린트 절약
- AdBannerSection: LocalContext 로 store 읽어 false 면 composable 자체 no-op return — 호출자(Settings/GroupSelect/Search) 분기 코드 불필요

## 추가 파일
- data/local/AdConfigStore.kt — Hilt singleton + Companion.read(context) 정적 진입점
- data/remote/ConfigRepository.kt — api.getConfig() → store.set() 단순 래퍼
- MongleApiService.kt — GET("config") + ApiConfigResponse data class

## 안전 기본값
- AdConfigStore 기본값 = true (광고 표시) → 첫 부팅 / 네트워크 실패 시 기존 동작 유지
- 운영자가 서버 ADS_ENABLED=false 로 OFF 한 뒤 다음 부팅부터 반영

## Test plan
- [ ] Android Studio compileDebugKotlin 통과
- [ ] 서버 ADS_ENABLED=true (기본) → 광고 노출 + AdMob init 정상
- [ ] 서버 ADS_ENABLED=false 로 변경 → 다음 부팅 시 AdBannerSection 미노출 + Logcat 에 "광고 비활성" 로그
- [ ] /config 호출 실패 (네트워크 OFF) → 직전 캐시 또는 기본값(true) 으로 동작 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)