### PR TITLE
fix(aos-push): 알림 진입 시 홈 데이터 강제 새로고침 (MG-133)

### DIFF
--- a/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/mongle/android/ui/root/RootViewModel.kt
@@ -384,6 +384,15 @@ class RootViewModel @Inject constructor(
                     }
             }
         }
+        // MG-133 — 알림 탭 진입 시 홈 데이터를 강제 새로고침해 다른 멤버의 답변 ✓ 가
+        // 즉시 반영되도록 한다. HomeScreen 이 컴포지션 안에 있으면 ON_RESUME 가
+        // 별도로 refresh 를 트리거하지만, 다른 탭(예: History)에서 알림을 탭했거나
+        // cold-start 직후에는 ON_RESUME 만으로는 누락 가능. 인증 + 가족 데이터가
+        // 준비된 상태일 때만 호출 — 미인증/그룹 미생성 케이스는 기존 부팅 흐름에서
+        // 알아서 loadHomeData() 가 도착한다.
+        if (type != null && _uiState.value.appState == AppState.Authenticated) {
+            loadHomeData()
+        }
     }
 
     fun clearPendingNotification() {


### PR DESCRIPTION
## Summary
- `handleNotificationTap()` 이 알림 type 만 기록하고 홈 데이터를 갱신하지 않아, 다른 탭(예: History)에서 알림을 탭했거나 cold-start 직후에는 ON_RESUME 만으로 누락되는 회귀.
- 인증 상태일 때 `loadHomeData()` 강제 호출 추가.
- 부모 이슈: [MG-130](https://ycompany.atlassian.net/browse/MG-130) · 본 이슈: [MG-133](https://ycompany.atlassian.net/browse/MG-133)

## Test plan
- [ ] 에뮬레이터: 그룹 멤버가 답변 → 다른 단말이 백그라운드 상태에서 알림 탭 → 홈에서 멤버 ✓ 즉시 표시
- [ ] 에뮬레이터: History 탭에 있을 때 알림 탭 → 홈으로 이동되며 최신 데이터 표시
- [ ] cold start 알림 탭 진입 회귀 없음
- [ ] 미인증 상태에서 `handleNotificationTap()` 호출 시 `loadHomeData()` 가 호출되지 않음을 Turbine 으로 확인